### PR TITLE
Fix server selection error

### DIFF
--- a/sim/simulate.h
+++ b/sim/simulate.h
@@ -99,11 +99,12 @@ namespace crimson {
 
       void add_servers(uint count,
 		       std::function<TS*(ServerId)> create_server_f) {
-	for (uint i = 0; i < count; ++i) {
-	  server_ids.push_back(server_count + i);
-	  servers[i] = create_server_f(server_count + i);
-	}
+	uint i = server_count;
 	server_count += count;
+	for (; i < server_count; ++i) {
+	  server_ids.push_back(i);
+	  servers[i] = create_server_f(i);
+	}
 
 	servers_created_time = now();
       }
@@ -111,10 +112,11 @@ namespace crimson {
 
       void add_clients(uint count,
 		       std::function<TC*(ClientId)> create_client_f) {
-	for (uint i = 0; i < count; ++i) {
-	  clients[i] = create_client_f(client_count + i);
-	}
+	uint i = client_count;
 	client_count += count;
+	for (; i < client_count; ++i) {
+	  clients[i] = create_client_f(i);
+	}
 
 	clients_created_time = now();
       }


### PR DESCRIPTION
Fix uninitialized value of client's server selection in the client initialization process.
The below table shows each client & request's server selection result.
Current:
==== Server Selected ====
     client:   0   1   2   3   4   5   6   7   8   9 .. 90  91  92  93  94  95  96  97  98  99
        r_0:   **0   0   0   0   0   0   0   0   0   0 ..  0   0   0   0   0   0   0   0   0  99**  >> at this time, client_count is not initialized
        r_1:   1   1   1   1   1   1   1   1   1   1  .. 91  92  93  94  95  96  97  98  99   0
        r_2:   2   3   4   5   6   7   8   9  10  11 .. 92  93  94  95  96  97  98  99   0   1

After:
==== Server Selected ====
     client:   0   1   2   3   4   5   6   7   8   9 .. 90  91  92  93  94  95  96  97  98  99
        r_0:   **0   1   2   3   4   5   6   7   8   9 .. 90  91  92  93  94  95  96  97  98  99**
        r_1:   1   2   3   4   5   6   7   8   9  10 .. 91  92  93  94  95  96  97  98  99   0
        r_2:   2   3   4   5   6   7   8   9  10  11 .. 92  93  94  95  96  97  98  99   0   1
