### PR TITLE
Add file based dmclock configuration parameter functionality

### DIFF
--- a/dmc_sim.conf
+++ b/dmc_sim.conf
@@ -1,0 +1,41 @@
+[global]
+server_count = 1
+client_count = 3
+server_types = 1
+client_types = 3
+server_random_selection = false
+server_soft_limit = false
+
+[client.0]
+client_wait = 0
+client_total_ops = 2000
+client_server_select_range = 1
+client_iops_goal = 200
+client_outstanding_ops = 32
+client_reservation = 0.0
+client_limit = 0.0
+client_weight = 1.0
+
+[client.1]
+client_wait = 5
+client_total_ops = 2000
+client_server_select_range = 1
+client_iops_goal = 200
+client_outstanding_ops = 32
+client_reservation = 0.0
+client_limit = 40.0
+client_weight = 1.0
+
+[client.2]
+client_wait = 10
+client_total_ops = 2000
+client_server_select_range = 1
+client_iops_goal = 200
+client_outstanding_ops = 32
+client_reservation = 0.0
+client_limit = 50.0
+client_weight = 2.0
+
+[server.0]
+server_iops = 160
+server_threads = 1

--- a/dmc_sim.conf
+++ b/dmc_sim.conf
@@ -1,12 +1,11 @@
 [global]
-server_count = 1
-client_count = 3
-server_types = 1
-client_types = 3
+server_groups = 1
+client_groups = 3
 server_random_selection = false
 server_soft_limit = false
 
 [client.0]
+client_count = 1
 client_wait = 0
 client_total_ops = 2000
 client_server_select_range = 1
@@ -17,6 +16,7 @@ client_limit = 0.0
 client_weight = 1.0
 
 [client.1]
+client_count = 1
 client_wait = 5
 client_total_ops = 2000
 client_server_select_range = 1
@@ -27,6 +27,7 @@ client_limit = 40.0
 client_weight = 1.0
 
 [client.2]
+client_count = 1
 client_wait = 10
 client_total_ops = 2000
 client_server_select_range = 1
@@ -37,5 +38,6 @@ client_limit = 50.0
 client_weight = 2.0
 
 [server.0]
+server_count = 1
 server_iops = 160
 server_threads = 1

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -9,8 +9,9 @@ set(local_flags "-Wall -pthread")
 
 set(ssched_sim_srcs test_ssched.cc test_ssched_main.cc)
 set(dmc_sim_srcs test_dmclock.cc test_dmclock_main.cc)
+set(config_srcs config.cc str_list.cc ConfUtils.cc)
 
-set_source_files_properties(${ssched_sim_srcs} ${dmc_sim_srcs} ${dmc_srcs}
+set_source_files_properties(${ssched_sim_srcs} ${dmc_sim_srcs} ${dmc_srcs} ${config_srcs}
   PROPERTIES
   COMPILE_FLAGS "${local_flags}"
   )
@@ -23,13 +24,13 @@ endif()
 
 # append warning flags to certain source files
 set_property(
-  SOURCE ${ssched_sim_srcs} ${dmc_sim_src}
+  SOURCE ${ssched_sim_srcs} ${dmc_sim_srcs} ${config_srcs}
   APPEND_STRING
   PROPERTY COMPILE_FLAGS "${warnings_off}"
   )
 
 add_executable(ssched_sim EXCLUDE_FROM_ALL ${ssched_sim_srcs})
-add_executable(dmc_sim EXCLUDE_FROM_ALL ${dmc_sim_srcs})
+add_executable(dmc_sim EXCLUDE_FROM_ALL ${dmc_sim_srcs} ${config_srcs})
 
 add_dependencies(dmc_sim dmclock)
 

--- a/sim/ConfUtils.cc
+++ b/sim/ConfUtils.cc
@@ -1,0 +1,574 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <algorithm>
+#include <errno.h>
+#include <list>
+#include <map>
+#include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <iostream>
+
+#include <assert.h>
+#include "ConfUtils.h"
+
+using std::cerr;
+using std::ostringstream;
+using std::pair;
+using std::string;
+
+#define MAX_CONFIG_FILE_SZ 0x40000000
+
+////////////////////////////// ConfLine //////////////////////////////
+ConfLine::
+ConfLine(const std::string &key_, const std::string val_,
+      const std::string newsection_, const std::string comment_, int line_no_)
+  : key(key_), val(val_), newsection(newsection_)
+{
+  // If you want to implement writable ConfFile support, you'll need to save
+  // the comment and line_no arguments here.
+}
+
+bool ConfLine::
+operator<(const ConfLine &rhs) const
+{
+  // We only compare keys.
+  // If you have more than one line with the same key in a given section, the
+  // last one wins.
+  if (key < rhs.key)
+    return true;
+  else
+    return false;
+}
+
+std::ostream &operator<<(std::ostream& oss, const ConfLine &l)
+{
+  oss << "ConfLine(key = '" << l.key << "', val='"
+      << l.val << "', newsection='" << l.newsection << "')";
+  return oss;
+}
+///////////////////////// ConfFile //////////////////////////
+ConfFile::
+ConfFile()
+{
+}
+
+ConfFile::
+~ConfFile()
+{
+}
+
+void ConfFile::
+clear()
+{
+  sections.clear();
+}
+
+/* We load the whole file into memory and then parse it.  Although this is not
+ * the optimal approach, it does mean that most of this code can be shared with
+ * the bufferlist loading function. Since bufferlists are always in-memory, the
+ * load_from_buffer interface works well for them.
+ * In general, configuration files should be a few kilobytes at maximum, so
+ * loading the whole configuration into memory shouldn't be a problem.
+ */
+int ConfFile::
+parse_file(const std::string &fname, std::deque<std::string> *errors,
+	   std::ostream *warnings)
+{
+  clear();
+
+  int ret = 0;
+  size_t sz;
+  char *buf = NULL;
+  char buf2[128];
+  FILE *fp = fopen(fname.c_str(), "r");
+  if (!fp) {
+    ret = -errno;
+    return ret;
+  }
+
+  struct stat st_buf;
+  if (fstat(fileno(fp), &st_buf)) {
+    ret = -errno;
+    ostringstream oss;
+    oss << "read_conf: failed to fstat '" << fname << "': " << strerror_r(ret, buf2, sizeof(buf2));
+    errors->push_back(oss.str());
+    goto done;
+  }
+
+  if (st_buf.st_size > MAX_CONFIG_FILE_SZ) {
+    ostringstream oss;
+    oss << "read_conf: config file '" << fname << "' is " << st_buf.st_size
+	<< " bytes, but the maximum is " << MAX_CONFIG_FILE_SZ;
+    errors->push_back(oss.str());
+    ret = -EINVAL;
+    goto done;
+  }
+
+  sz = (size_t)st_buf.st_size;
+  buf = (char*)malloc(sz);
+  if (!buf) {
+    ret = -ENOMEM;
+    goto done;
+  }
+
+  if (fread(buf, 1, sz, fp) != sz) {
+    if (ferror(fp)) {
+      ret = -errno;
+      ostringstream oss;
+      oss << "read_conf: fread error while reading '" << fname << "': "
+	  << strerror_r(ret, buf2, sizeof(buf2));
+      errors->push_back(oss.str());
+      goto done;
+    }
+    else {
+      ostringstream oss;
+      oss << "read_conf: unexpected EOF while reading '" << fname << "': "
+	  << "possible concurrent modification?";
+      errors->push_back(oss.str());
+      ret = -EIO;
+      goto done;
+    }
+  }
+
+  load_from_buffer(buf, sz, errors, warnings);
+  ret = 0;
+
+done:
+  free(buf);
+  fclose(fp);
+  return ret;
+}
+
+int ConfFile::
+read(const std::string &section, const std::string &key, std::string &val) const
+{
+  string k(normalize_key_name(key));
+
+  const_section_iter_t s = sections.find(section);
+  if (s == sections.end())
+    return -ENOENT;
+  ConfLine exemplar(k, "", "", "", 0);
+  ConfSection::const_line_iter_t l = s->second.lines.find(exemplar);
+  if (l == s->second.lines.end())
+    return -ENOENT;
+  val = l->val;
+  return 0;
+}
+
+ConfFile::const_section_iter_t ConfFile::
+sections_begin() const
+{
+  return sections.begin();
+}
+
+ConfFile::const_section_iter_t ConfFile::
+sections_end() const
+{
+  return sections.end();
+}
+
+void ConfFile::
+trim_whitespace(std::string &str, bool strip_internal)
+{
+  // strip preceding
+  const char *in = str.c_str();
+  while (true) {
+    char c = *in;
+    if ((!c) || (!isspace(c)))
+      break;
+    ++in;
+  }
+  char output[strlen(in) + 1];
+  strcpy(output, in);
+
+  // strip trailing
+  char *o = output + strlen(output);
+  while (true) {
+    if (o == output)
+      break;
+    --o;
+    if (!isspace(*o)) {
+      ++o;
+      *o = '\0';
+      break;
+    }
+  }
+
+  if (!strip_internal) {
+    str.assign(output);
+    return;
+  }
+
+  // strip internal
+  char output2[strlen(output) + 1];
+  char *out2 = output2;
+  bool prev_was_space = false;
+  for (char *u = output; *u; ++u) {
+    char c = *u;
+    if (isspace(c)) {
+      if (!prev_was_space)
+	*out2++ = c;
+      prev_was_space = true;
+    }
+    else {
+      *out2++ = c;
+      prev_was_space = false;
+    }
+  }
+  *out2++ = '\0';
+  str.assign(output2);
+}
+
+/* Normalize a key name.
+ *
+ * Normalized key names have no leading or trailing whitespace, and all
+ * whitespace is stored as underscores.  The main reason for selecting this
+ * normal form is so that in common/config.cc, we can use a macro to stringify
+ * the field names of md_config_t and get a key in normal form.
+ */
+std::string ConfFile::
+normalize_key_name(const std::string &key)
+{
+  string k(key);
+  ConfFile::trim_whitespace(k, true);
+  std::replace(k.begin(), k.end(), ' ', '_');
+  return k;
+}
+
+std::ostream &operator<<(std::ostream &oss, const ConfFile &cf)
+{
+  for (ConfFile::const_section_iter_t s = cf.sections_begin();
+       s != cf.sections_end(); ++s) {
+    oss << "[" << s->first << "]\n";
+    for (ConfSection::const_line_iter_t l = s->second.lines.begin();
+	 l != s->second.lines.end(); ++l) {
+      if (!l->key.empty()) {
+	oss << "\t" << l->key << " = \"" << l->val << "\"\n";
+      }
+    }
+  }
+  return oss;
+}
+
+void ConfFile::
+load_from_buffer(const char *buf, size_t sz, std::deque<std::string> *errors,
+		 std::ostream *warnings)
+{
+  errors->clear();
+
+  section_iter_t::value_type vt("global", ConfSection());
+  pair < section_iter_t, bool > vr(sections.insert(vt));
+  assert(vr.second);
+  section_iter_t cur_section = vr.first;
+  std::string acc;
+
+  const char *b = buf;
+  int line_no = 0;
+  size_t line_len = -1;
+  size_t rem = sz;
+  while (1) {
+    b += line_len + 1;
+    rem -= line_len + 1;
+    if (rem == 0)
+      break;
+    line_no++;
+
+    // look for the next newline
+    const char *end = (const char*)memchr(b, '\n', rem);
+    if (!end) {
+      ostringstream oss;
+      oss << "read_conf: ignoring line " << line_no << " because it doesn't "
+	  << "end with a newline! Please end the config file with a newline.";
+      errors->push_back(oss.str());
+      break;
+    }
+
+    // find length of line, and search for NULLs
+    line_len = 0;
+    bool found_null = false;
+    for (const char *tmp = b; tmp != end; ++tmp) {
+      line_len++;
+      if (*tmp == '\0') {
+	found_null = true;
+      }
+    }
+
+    if (found_null) {
+      ostringstream oss;
+      oss << "read_conf: ignoring line " << line_no << " because it has "
+	  << "an embedded null.";
+      errors->push_back(oss.str());
+      acc.clear();
+      continue;
+    }
+
+    if ((line_len >= 1) && (b[line_len-1] == '\\')) {
+      // A backslash at the end of a line serves as a line continuation marker.
+      // Combine the next line with this one.
+      // Remove the backslash itself from the text.
+      acc.append(b, line_len - 1);
+      continue;
+    }
+
+    acc.append(b, line_len);
+
+    //cerr << "acc = '" << acc << "'" << std::endl;
+    ConfLine *cline = process_line(line_no, acc.c_str(), errors);
+    acc.clear();
+    if (!cline)
+      continue;
+    const std::string &csection(cline->newsection);
+    if (!csection.empty()) {
+      std::map <std::string, ConfSection>::value_type nt(csection, ConfSection());
+      pair < section_iter_t, bool > nr(sections.insert(nt));
+      cur_section = nr.first;
+    }
+    else {
+      if (cur_section->second.lines.count(*cline)) {
+	// replace an existing key/line in this section, so that
+	//  [mysection]
+	//    foo = 1
+	//    foo = 2
+	// will result in foo = 2.
+	cur_section->second.lines.erase(*cline);
+	if (cline->key.length() && warnings)
+	  *warnings << "warning: line " << line_no << ": '" << cline->key << "' in section '"
+		    << cur_section->first << "' redefined " << std::endl;
+      }
+      // add line to current section
+      //std::cerr << "cur_section = " << cur_section->first << ", " << *cline << std::endl;
+      cur_section->second.lines.insert(*cline);
+    }
+    delete cline;
+  }
+
+  if (!acc.empty()) {
+    ostringstream oss;
+    oss << "read_conf: don't end with lines that end in backslashes!";
+    errors->push_back(oss.str());
+  }
+}
+
+/*
+ * A simple state-machine based parser.
+ * This probably could/should be rewritten with something like boost::spirit
+ * or yacc if the grammar ever gets more complex.
+ */
+ConfLine* ConfFile::
+process_line(int line_no, const char *line, std::deque<std::string> *errors)
+{
+  enum acceptor_state_t {
+    ACCEPT_INIT,
+    ACCEPT_SECTION_NAME,
+    ACCEPT_KEY,
+    ACCEPT_VAL_START,
+    ACCEPT_UNQUOTED_VAL,
+    ACCEPT_QUOTED_VAL,
+    ACCEPT_COMMENT_START,
+    ACCEPT_COMMENT_TEXT,
+  };
+  const char *l = line;
+  acceptor_state_t state = ACCEPT_INIT;
+  string key, val, newsection, comment;
+  bool escaping = false;
+  while (true) {
+    char c = *l++;
+    switch (state) {
+      case ACCEPT_INIT:
+	if (c == '\0')
+	  return NULL; // blank line. Not an error, but not interesting either.
+	else if (c == '[')
+	  state = ACCEPT_SECTION_NAME;
+	else if ((c == '#') || (c == ';'))
+	  state = ACCEPT_COMMENT_TEXT;
+	else if (c == ']') {
+	  ostringstream oss;
+	  oss << "unexpected right bracket at char " << (l - line)
+	      << ", line " << line_no;
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	else if (isspace(c)) {
+	  // ignore whitespace here
+	}
+	else {
+	  // try to accept this character as a key
+	  state = ACCEPT_KEY;
+	  --l;
+	}
+	break;
+      case ACCEPT_SECTION_NAME:
+	if (c == '\0') {
+	  ostringstream oss;
+	  oss << "error parsing new section name: expected right bracket "
+	      << "at char " << (l - line) << ", line " << line_no;
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	else if ((c == ']') && (!escaping)) {
+	  trim_whitespace(newsection, true);
+	  if (newsection.empty()) {
+	    ostringstream oss;
+	    oss << "error parsing new section name: no section name found? "
+	        << "at char " << (l - line) << ", line " << line_no;
+	    errors->push_back(oss.str());
+	    return NULL;
+	  }
+	  state = ACCEPT_COMMENT_START;
+	}
+	else if (((c == '#') || (c == ';')) && (!escaping)) {
+	  ostringstream oss;
+	  oss << "unexpected comment marker while parsing new section name, at "
+	      << "char " << (l - line) << ", line " << line_no;
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	else if ((c == '\\') && (!escaping)) {
+	  escaping = true;
+	}
+	else {
+	  escaping = false;
+	  newsection += c;
+	}
+	break;
+      case ACCEPT_KEY:
+	if ((((c == '#') || (c == ';')) && (!escaping)) || (c == '\0')) {
+	  ostringstream oss;
+	  if (c == '\0') {
+	    oss << "end of key=val line " << line_no
+	        << " reached, no \"=val\" found...missing =?";
+	  } else {
+	    oss << "unexpected character while parsing putative key value, "
+		<< "at char " << (l - line) << ", line " << line_no;
+	  }
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	else if ((c == '=') && (!escaping)) {
+	  key = normalize_key_name(key);
+	  if (key.empty()) {
+	    ostringstream oss;
+	    oss << "error parsing key name: no key name found? "
+	        << "at char " << (l - line) << ", line " << line_no;
+	    errors->push_back(oss.str());
+	    return NULL;
+	  }
+	  state = ACCEPT_VAL_START;
+	}
+	else if ((c == '\\') && (!escaping)) {
+	  escaping = true;
+	}
+	else {
+	  escaping = false;
+	  key += c;
+	}
+	break;
+      case ACCEPT_VAL_START:
+	if (c == '\0')
+	  return new ConfLine(key, val, newsection, comment, line_no);
+	else if ((c == '#') || (c == ';'))
+	  state = ACCEPT_COMMENT_TEXT;
+	else if (c == '"')
+	  state = ACCEPT_QUOTED_VAL;
+	else if (isspace(c)) {
+	  // ignore whitespace
+	}
+	else {
+	  // try to accept character as a val
+	  state = ACCEPT_UNQUOTED_VAL;
+	  --l;
+	}
+	break;
+      case ACCEPT_UNQUOTED_VAL:
+	if (c == '\0') {
+	  if (escaping) {
+	    ostringstream oss;
+	    oss << "error parsing value name: unterminated escape sequence "
+	        << "at char " << (l - line) << ", line " << line_no;
+	    errors->push_back(oss.str());
+	    return NULL;
+	  }
+	  trim_whitespace(val, false);
+	  return new ConfLine(key, val, newsection, comment, line_no);
+	}
+	else if (((c == '#') || (c == ';')) && (!escaping)) {
+	  trim_whitespace(val, false);
+	  state = ACCEPT_COMMENT_TEXT;
+	}
+	else if ((c == '\\') && (!escaping)) {
+	  escaping = true;
+	}
+	else {
+	  escaping = false;
+	  val += c;
+	}
+	break;
+      case ACCEPT_QUOTED_VAL:
+	if (c == '\0') {
+	  ostringstream oss;
+	  oss << "found opening quote for value, but not the closing quote. "
+	      << "line " << line_no;
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	else if ((c == '"') && (!escaping)) {
+	  state = ACCEPT_COMMENT_START;
+	}
+	else if ((c == '\\') && (!escaping)) {
+	  escaping = true;
+	}
+	else {
+	  escaping = false;
+	  // Add anything, including whitespace.
+	  val += c;
+	}
+	break;
+      case ACCEPT_COMMENT_START:
+	if (c == '\0') {
+	  return new ConfLine(key, val, newsection, comment, line_no);
+	}
+	else if ((c == '#') || (c == ';')) {
+	  state = ACCEPT_COMMENT_TEXT;
+	}
+	else if (isspace(c)) {
+	  // ignore whitespace
+	}
+	else {
+	  ostringstream oss;
+	  oss << "unexpected character at char " << (l - line) << " of line "
+	      << line_no;
+	  errors->push_back(oss.str());
+	  return NULL;
+	}
+	break;
+      case ACCEPT_COMMENT_TEXT:
+	if (c == '\0')
+	  return new ConfLine(key, val, newsection, comment, line_no);
+	else
+	  comment += c;
+	break;
+      default:
+	assert(0);
+	break;
+    }
+    assert(c != '\0'); // We better not go past the end of the input string.
+  }
+}

--- a/sim/ConfUtils.h
+++ b/sim/ConfUtils.h
@@ -1,0 +1,83 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_CONFUTILS_H
+#define CEPH_CONFUTILS_H
+
+#include <deque>
+#include <map>
+#include <set>
+#include <string>
+
+/*
+ * Ceph configuration file support.
+ *
+ * This class loads an INI-style configuration from a file or bufferlist, and
+ * holds it in memory. In general, an INI configuration file is composed of
+ * sections, which contain key/value pairs. You can put comments on the end of
+ * lines by using either a hash mark (#) or the semicolon (;).
+ *
+ * You can get information out of ConfFile by calling get_key or by examining
+ * individual sections.
+ *
+ * This class could be extended to support modifying configuration files and
+ * writing them back out without too much difficulty. Currently, this is not
+ * implemented, and the file is read-only.
+ */
+class ConfLine {
+public:
+  ConfLine(const std::string &key_, const std::string val_,
+	   const std::string newsection_, const std::string comment_, int line_no_);
+  bool operator<(const ConfLine &rhs) const;
+  friend std::ostream &operator<<(std::ostream& oss, const ConfLine &l);
+
+  std::string key, val, newsection;
+};
+
+class ConfSection {
+public:
+  typedef std::set <ConfLine>::const_iterator const_line_iter_t;
+
+  std::set <ConfLine> lines;
+};
+
+class ConfFile {
+public:
+  typedef std::map <std::string, ConfSection>::iterator section_iter_t;
+  typedef std::map <std::string, ConfSection>::const_iterator const_section_iter_t;
+
+  ConfFile();
+  ~ConfFile();
+  void clear();
+  int parse_file(const std::string &fname, std::deque<std::string> *errors, std::ostream *warnings);
+  int read(const std::string &section, const std::string &key,
+	      std::string &val) const;
+
+  const_section_iter_t sections_begin() const;
+  const_section_iter_t sections_end() const;
+
+  static void trim_whitespace(std::string &str, bool strip_internal);
+  static std::string normalize_key_name(const std::string &key);
+  friend std::ostream &operator<<(std::ostream &oss, const ConfFile &cf);
+
+private:
+  void load_from_buffer(const char *buf, size_t sz,
+			std::deque<std::string> *errors, std::ostream *warnings);
+  static ConfLine* process_line(int line_no, const char *line,
+			        std::deque<std::string> *errors);
+
+  std::map <std::string, ConfSection> sections;
+};
+
+#endif

--- a/sim/config.cc
+++ b/sim/config.cc
@@ -122,32 +122,32 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
   }
 
   std::string val;
-  if (!cf.read("global", "server_count", val))
-    g_conf.server_count = std::stoul(val);
-  if (!cf.read("global", "client_count", val))
-    g_conf.client_count = std::stoul(val);
-  if (!cf.read("global", "server_types", val))
-    g_conf.server_types = std::stoul(val);
-  if (!cf.read("global", "client_types", val))
-    g_conf.client_types = std::stoul(val);
+  if (!cf.read("global", "server_groups", val))
+    g_conf.server_groups = std::stoul(val);
+  if (!cf.read("global", "client_groups", val))
+    g_conf.client_groups = std::stoul(val);
   if (!cf.read("global", "server_random_selection", val))
     g_conf.server_random_selection = stobool(val);
   if (!cf.read("global", "server_soft_limit", val))
     g_conf.server_soft_limit = stobool(val);
 
-  for (uint i = 0; i < g_conf.server_types; i++) {
-    srv_type_t st;
+  for (uint i = 0; i < g_conf.server_groups; i++) {
+    srv_group_t st;
     std::string section = "server." + std::to_string(i);
+    if (!cf.read(section, "server_count", val))
+      st.server_count = std::stoul(val);
     if (!cf.read(section, "server_iops", val))
       st.server_iops = std::stoul(val);
     if (!cf.read(section, "server_threads", val))
       st.server_threads = std::stoul(val);
-    g_conf.srv_type.push_back(st);
+    g_conf.srv_group.push_back(st);
   }
 
-  for (uint i = 0; i < g_conf.client_types; i++) {
-    cli_type_t ct;
+  for (uint i = 0; i < g_conf.client_groups; i++) {
+    cli_group_t ct;
     std::string section = "client." + std::to_string(i);
+    if (!cf.read(section, "client_count", val))
+      ct.client_count = std::stoul(val);
     if (!cf.read(section, "client_wait", val))
       ct.client_wait = std::chrono::seconds(std::stoul(val));
     if (!cf.read(section, "client_total_ops", val))
@@ -164,7 +164,7 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
       ct.client_limit = std::stod(val);
     if (!cf.read(section, "client_weight", val))
       ct.client_weight = std::stod(val);
-    g_conf.cli_type.push_back(ct);
+    g_conf.cli_group.push_back(ct);
   }
 
   return 0;

--- a/sim/config.cc
+++ b/sim/config.cc
@@ -1,0 +1,171 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+
+#include <unistd.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include <iostream>
+#include <vector>
+#include <list>
+
+#include "config.h"
+#include "str_list.h"
+
+
+static void dashes_to_underscores(const char *input, char *output) {
+  char c = 0;
+  char *o = output;
+  const char *i = input;
+  // first two characters are copied as-is
+  *o = *i++;
+  if (*o++ == '\0')
+    return;
+  *o = *i++;
+  if (*o++ == '\0')
+    return;
+  for (; ((c = *i)); ++i) {
+    if (c == '=') {
+      strcpy(o, i);
+      return;
+    }
+    if (c == '-')
+      *o++ = '_';
+    else
+      *o++ = c;
+  }
+  *o++ = '\0';
+}
+
+static int va_ceph_argparse_witharg(std::vector<const char*> &args,
+	std::vector<const char*>::iterator &i, std::string *ret,
+	std::ostream &oss, va_list ap) {
+  const char *first = *i;
+  char tmp[strlen(first)+1];
+  dashes_to_underscores(first, tmp);
+  first = tmp;
+
+  // does this argument match any of the possibilities?
+  while (1) {
+    const char *a = va_arg(ap, char*);
+    if (a == NULL)
+      return 0;
+    int strlen_a = strlen(a);
+    char a2[strlen_a+1];
+    dashes_to_underscores(a, a2);
+    if (strncmp(a2, first, strlen(a2)) == 0) {
+      if (first[strlen_a] == '=') {
+	*ret = first + strlen_a + 1;
+	i = args.erase(i);
+	return 1;
+      }
+      else if (first[strlen_a] == '\0') {
+	// find second part (or not)
+	if (i+1 == args.end()) {
+	  oss << "Option " << *i << " requires an argument." << std::endl;
+	  i = args.erase(i);
+	  return -EINVAL;
+	}
+	i = args.erase(i);
+	*ret = *i;
+	i = args.erase(i);
+	return 1;
+      }
+    }
+  }
+}
+
+bool crimson::qos_simulation::ceph_argparse_witharg(std::vector<const char*> &args,
+	std::vector<const char*>::iterator &i, std::string *ret, ...) {
+  int r;
+  va_list ap;
+  va_start(ap, ret);
+  r = va_ceph_argparse_witharg(args, i, ret, std::cerr, ap);
+  va_end(ap);
+  if (r < 0)
+    _exit(1);
+  return r != 0;
+}
+
+void crimson::qos_simulation::ceph_argparse_early_args(std::vector<const char*>& args, std::string *conf_file_list) {
+  std::string val;
+
+  std::vector<const char *> orig_args = args;
+
+  for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
+    if (ceph_argparse_witharg(args, i, &val, "--conf", "-c", (char*)NULL)) {
+      *conf_file_list = val;
+    }
+    else {
+      // ignore
+      ++i;
+    }
+  }
+  return;
+}
+
+static bool stobool(const std::string & v) {
+    return !v.empty () &&
+           (strcasecmp (v.c_str (), "true") == 0 ||
+	   atoi (v.c_str ()) != 0);
+}
+
+int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_config_t &g_conf) {
+  ConfFile cf;
+  std::deque<std::string> err;
+  std::ostringstream warn;
+  int ret = cf.parse_file(fname.c_str(), &err, &warn);
+  if (ret) {
+    // error
+    return ret;
+  }
+
+  std::string val;
+  if (!cf.read("global", "server_count", val))
+    g_conf.server_count = std::stoul(val);
+  if (!cf.read("global", "client_count", val))
+    g_conf.client_count = std::stoul(val);
+  if (!cf.read("global", "server_types", val))
+    g_conf.server_types = std::stoul(val);
+  if (!cf.read("global", "client_types", val))
+    g_conf.client_types = std::stoul(val);
+  if (!cf.read("global", "server_random_selection", val))
+    g_conf.server_random_selection = stobool(val);
+  if (!cf.read("global", "server_soft_limit", val))
+    g_conf.server_soft_limit = stobool(val);
+
+  for (uint i = 0; i < g_conf.server_types; i++) {
+    srv_type_t st;
+    std::string section = "server." + std::to_string(i);
+    if (!cf.read(section, "server_iops", val))
+      st.server_iops = std::stoul(val);
+    if (!cf.read(section, "server_threads", val))
+      st.server_threads = std::stoul(val);
+    g_conf.srv_type.push_back(st);
+  }
+
+  for (uint i = 0; i < g_conf.client_types; i++) {
+    cli_type_t ct;
+    std::string section = "client." + std::to_string(i);
+    if (!cf.read(section, "client_wait", val))
+      ct.client_wait = std::chrono::seconds(std::stoul(val));
+    if (!cf.read(section, "client_total_ops", val))
+      ct.client_total_ops = std::stoul(val);
+    if (!cf.read(section, "client_server_select_range", val))
+      ct.client_server_select_range = std::stoul(val);
+    if (!cf.read(section, "client_iops_goal", val))
+      ct.client_iops_goal = std::stoul(val);
+    if (!cf.read(section, "client_outstanding_ops", val))
+      ct.client_outstanding_ops = std::stoul(val);
+    if (!cf.read(section, "client_reservation", val))
+      ct.client_reservation = std::stod(val);
+    if (!cf.read(section, "client_limit", val))
+      ct.client_limit = std::stod(val);
+    if (!cf.read(section, "client_weight", val))
+      ct.client_weight = std::stod(val);
+    g_conf.cli_type.push_back(ct);
+  }
+
+  return 0;
+}

--- a/sim/config.h
+++ b/sim/config.h
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <vector>
 #include <sstream>
+#include <iomanip>
 
 #include "ConfUtils.h"
 
@@ -17,7 +18,8 @@
 namespace crimson {
   namespace qos_simulation {
 
-    struct cli_type_t {
+    struct cli_group_t {
+      uint client_count;
       std::chrono::seconds client_wait;
       uint client_total_ops;
       uint client_server_select_range;
@@ -27,88 +29,101 @@ namespace crimson {
       double client_limit;
       double client_weight;
 
-      cli_type_t() :
-	client_wait(std::chrono::seconds(0)),
-	client_total_ops(1000),
-	client_server_select_range(10),
-	client_iops_goal(50),
-	client_outstanding_ops(100),
-	client_reservation(20.0),
-	client_limit(60.0),
-	client_weight(1.0)
+      cli_group_t(uint _client_count = 100,
+		  uint _client_wait = 0,
+		  uint _client_total_ops = 1000,
+		  uint _client_server_select_range = 10,
+		  uint _client_iops_goal = 50,
+		  uint _client_outstanding_ops = 100,
+		  double _client_reservation = 20.0,
+		  double _client_limit = 60.0,
+		  double _client_weight = 1.0) :
+	client_count(_client_count),
+	client_wait(std::chrono::seconds(_client_wait)),
+	client_total_ops(_client_total_ops),
+	client_server_select_range(_client_server_select_range),
+	client_iops_goal(_client_iops_goal),
+	client_outstanding_ops(_client_outstanding_ops),
+	client_reservation(_client_reservation),
+	client_limit(_client_limit),
+	client_weight(_client_weight)
       {
 	// empty
       }
 
       friend std::ostream& operator<<(std::ostream& out,
-	  const cli_type_t& cli_type) {
+	  const cli_group_t& cli_group) {
 	out <<
-	  "client_wait:" << cli_type.client_wait.count() << "\n" <<
-	  "client_total_ops:" << cli_type.client_total_ops << "\n" <<
-	  "client_server_select_range:" << cli_type.client_server_select_range << "\n" <<
-	  "client_iops_goal:" << cli_type.client_iops_goal << "\n" <<
-	  "client_outstanding_ops:" << cli_type.client_outstanding_ops << "\n" <<
-	  "client_reservation:" << cli_type.client_reservation << "\n" <<
-	  "client_limit:" << cli_type.client_limit << "\n" <<
-	  "client_weight:" << cli_type.client_weight;
+	  "client_count = " << cli_group.client_count << "\n" <<
+	  "client_wait = " << cli_group.client_wait.count() << "\n" <<
+	  "client_total_ops = " << cli_group.client_total_ops << "\n" <<
+	  "client_server_select_range = " << cli_group.client_server_select_range << "\n" <<
+	  "client_iops_goal = " << cli_group.client_iops_goal << "\n" <<
+	  "client_outstanding_ops = " << cli_group.client_outstanding_ops << "\n" <<
+	  std::fixed << std::setprecision(1) <<
+	  "client_reservation = " << cli_group.client_reservation << "\n" <<
+	  "client_limit = " << cli_group.client_limit << "\n" <<
+	  "client_weight = " << cli_group.client_weight;
 	return out;
       }
-    }; // class cli_type_t
+    }; // class cli_group_t
 
 
-    struct srv_type_t {
+    struct srv_group_t {
+      uint server_count;
       uint server_iops;
       uint server_threads;
 
-      srv_type_t() :
-	server_iops(40),
-	server_threads(1)
+      srv_group_t(uint _server_count = 100,
+		  uint _server_iops = 40,
+		  uint _server_threads = 1) :
+	server_count(_server_count),
+	server_iops(_server_iops),
+	server_threads(_server_threads)
       {
 	// empty
       }
 
       friend std::ostream& operator<<(std::ostream& out,
-	  const srv_type_t& srv_type) {
+	  const srv_group_t& srv_group) {
 	out <<
-	  "server_iops:" << srv_type.server_iops << "\n" <<
-	  "server_threads:" << srv_type.server_threads;
+	  "server_count = " << srv_group.server_count << "\n" <<
+	  "server_iops = " << srv_group.server_iops << "\n" <<
+	  "server_threads = " << srv_group.server_threads;
 	return out;
       }
-    }; // class srv_type_t
+    }; // class srv_group_t
 
 
     struct sim_config_t {
-      uint server_count;
-      uint client_count;
-      uint server_types;
-      uint client_types;
+      uint server_groups;
+      uint client_groups;
       bool server_random_selection;
       bool server_soft_limit;
 
-      std::vector<cli_type_t> cli_type;
-      std::vector<srv_type_t> srv_type;
+      std::vector<cli_group_t> cli_group;
+      std::vector<srv_group_t> srv_group;
 
-      sim_config_t() :
-	server_count(100),
-	client_count(100),
-	server_types(1),
-	client_types(1),
-	server_random_selection(false),
-	server_soft_limit(true)
+      sim_config_t(uint _server_groups = 1,
+		   uint _client_groups = 1,
+		   bool _server_random_selection = false,
+		   bool _server_soft_limit = true) :
+	server_groups(_server_groups),
+	client_groups(_client_groups),
+	server_random_selection(_server_random_selection),
+	server_soft_limit(_server_soft_limit)
       {
-	srv_type.reserve(server_types);
-	cli_type.reserve(client_types);
+	srv_group.reserve(server_groups);
+	cli_group.reserve(client_groups);
       }
 
       friend std::ostream& operator<<(std::ostream& out,
 	  const sim_config_t& sim_config) {
 	out <<
-	  "server_count:" << sim_config.server_count << "\n" <<
-	  "client_count:" << sim_config.client_count << "\n" <<
-	  "server_types:" << sim_config.server_types << "\n" <<
-	  "client_types:" << sim_config.client_types << "\n" <<
-	  "server_random_selection:" << sim_config.server_random_selection << "\n" <<
-	  "server_soft_limit:" << sim_config.server_soft_limit;
+	  "server_groups = " << sim_config.server_groups << "\n" <<
+	  "client_groups = " << sim_config.client_groups << "\n" <<
+	  "server_random_selection = " << sim_config.server_random_selection << "\n" <<
+	  "server_soft_limit = " << sim_config.server_soft_limit;
 	return out;
       }
     }; // class sim_config_t

--- a/sim/config.h
+++ b/sim/config.h
@@ -1,0 +1,123 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+
+#pragma once
+
+
+#include <string.h>
+
+#include <chrono>
+#include <vector>
+#include <sstream>
+
+#include "ConfUtils.h"
+
+
+namespace crimson {
+  namespace qos_simulation {
+
+    struct cli_type_t {
+      std::chrono::seconds client_wait;
+      uint client_total_ops;
+      uint client_server_select_range;
+      uint client_iops_goal;
+      uint client_outstanding_ops;
+      double client_reservation;
+      double client_limit;
+      double client_weight;
+
+      cli_type_t() :
+	client_wait(std::chrono::seconds(0)),
+	client_total_ops(1000),
+	client_server_select_range(10),
+	client_iops_goal(50),
+	client_outstanding_ops(100),
+	client_reservation(20.0),
+	client_limit(60.0),
+	client_weight(1.0)
+      {
+	// empty
+      }
+
+      friend std::ostream& operator<<(std::ostream& out,
+	  const cli_type_t& cli_type) {
+	out <<
+	  "client_wait:" << cli_type.client_wait.count() << "\n" <<
+	  "client_total_ops:" << cli_type.client_total_ops << "\n" <<
+	  "client_server_select_range:" << cli_type.client_server_select_range << "\n" <<
+	  "client_iops_goal:" << cli_type.client_iops_goal << "\n" <<
+	  "client_outstanding_ops:" << cli_type.client_outstanding_ops << "\n" <<
+	  "client_reservation:" << cli_type.client_reservation << "\n" <<
+	  "client_limit:" << cli_type.client_limit << "\n" <<
+	  "client_weight:" << cli_type.client_weight;
+	return out;
+      }
+    }; // class cli_type_t
+
+
+    struct srv_type_t {
+      uint server_iops;
+      uint server_threads;
+
+      srv_type_t() :
+	server_iops(40),
+	server_threads(1)
+      {
+	// empty
+      }
+
+      friend std::ostream& operator<<(std::ostream& out,
+	  const srv_type_t& srv_type) {
+	out <<
+	  "server_iops:" << srv_type.server_iops << "\n" <<
+	  "server_threads:" << srv_type.server_threads;
+	return out;
+      }
+    }; // class srv_type_t
+
+
+    struct sim_config_t {
+      uint server_count;
+      uint client_count;
+      uint server_types;
+      uint client_types;
+      bool server_random_selection;
+      bool server_soft_limit;
+
+      std::vector<cli_type_t> cli_type;
+      std::vector<srv_type_t> srv_type;
+
+      sim_config_t() :
+	server_count(100),
+	client_count(100),
+	server_types(1),
+	client_types(1),
+	server_random_selection(false),
+	server_soft_limit(true)
+      {
+	srv_type.reserve(server_types);
+	cli_type.reserve(client_types);
+      }
+
+      friend std::ostream& operator<<(std::ostream& out,
+	  const sim_config_t& sim_config) {
+	out <<
+	  "server_count:" << sim_config.server_count << "\n" <<
+	  "client_count:" << sim_config.client_count << "\n" <<
+	  "server_types:" << sim_config.server_types << "\n" <<
+	  "client_types:" << sim_config.client_types << "\n" <<
+	  "server_random_selection:" << sim_config.server_random_selection << "\n" <<
+	  "server_soft_limit:" << sim_config.server_soft_limit;
+	return out;
+      }
+    }; // class sim_config_t
+
+
+    bool ceph_argparse_witharg(std::vector<const char*> &args,
+	std::vector<const char*>::iterator &i, std::string *ret, ...);
+    void ceph_argparse_early_args(std::vector<const char*>& args, std::string *conf_file_list);
+    int parse_config_file(const std::string &fname, sim_config_t &g_conf);
+
+  }; // namespace qos_simulation
+}; // namespace crimson

--- a/sim/str_list.cc
+++ b/sim/str_list.cc
@@ -1,0 +1,106 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2009-2010 Dreamhost
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "str_list.h"
+
+using std::string;
+using std::vector;
+using std::set;
+using std::list;
+
+static bool get_next_token(const string &s, size_t& pos, const char *delims, string& token)
+{
+  int start = s.find_first_not_of(delims, pos);
+  int end;
+
+  if (start < 0){
+    pos = s.size();
+    return false;
+  }
+
+  end = s.find_first_of(delims, start);
+  if (end >= 0)
+    pos = end + 1;
+  else {
+    pos = end = s.size();
+  }
+
+  token = s.substr(start, end - start);
+  return true;
+}
+
+void get_str_list(const string& str, const char *delims, list<string>& str_list)
+{
+  size_t pos = 0;
+  string token;
+
+  str_list.clear();
+
+  while (pos < str.size()) {
+    if (get_next_token(str, pos, delims, token)) {
+      if (token.size() > 0) {
+        str_list.push_back(token);
+      }
+    }
+  }
+}
+
+void get_str_list(const string& str, list<string>& str_list)
+{
+  const char *delims = ";,= \t";
+  return get_str_list(str, delims, str_list);
+}
+
+void get_str_vec(const string& str, const char *delims, vector<string>& str_vec)
+{
+  size_t pos = 0;
+  string token;
+  str_vec.clear();
+
+  while (pos < str.size()) {
+    if (get_next_token(str, pos, delims, token)) {
+      if (token.size() > 0) {
+        str_vec.push_back(token);
+      }
+    }
+  }
+}
+
+void get_str_vec(const string& str, vector<string>& str_vec)
+{
+  const char *delims = ";,= \t";
+  return get_str_vec(str, delims, str_vec);
+}
+
+void get_str_set(const string& str, const char *delims, set<string>& str_set)
+{
+  size_t pos = 0;
+  string token;
+
+  str_set.clear();
+
+  while (pos < str.size()) {
+    if (get_next_token(str, pos, delims, token)) {
+      if (token.size() > 0) {
+        str_set.insert(token);
+      }
+    }
+  }
+}
+
+void get_str_set(const string& str, set<string>& str_set)
+{
+  const char *delims = ";,= \t";
+  return get_str_set(str, delims, str_set);
+}

--- a/sim/str_list.h
+++ b/sim/str_list.h
@@ -1,0 +1,94 @@
+#ifndef CEPH_STRLIST_H
+#define CEPH_STRLIST_H
+
+#include <list>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+/**
+ * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_list**.
+ * 
+ * @param [in] str String to split and save as list
+ * @param [out] str_list List modified containing str after it has been split
+**/
+extern void get_str_list(const std::string& str,
+			 std::list<std::string>& str_list);
+
+/**
+ * Split **str** into a list of strings, using the **delims** delimiters and output the result in **str_list**.
+ * 
+ * @param [in] str String to split and save as list
+ * @param [in] delims characters used to split **str**
+ * @param [out] str_list List modified containing str after it has been split
+**/
+extern void get_str_list(const std::string& str,
+                         const char *delims,
+			 std::list<std::string>& str_list);
+
+/**
+ * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_vec**.
+ * 
+ * @param [in] str String to split and save as Vector
+ * @param [out] str_vec Vector modified containing str after it has been split
+**/
+extern void get_str_vec(const std::string& str,
+			 std::vector<std::string>& str_vec);
+
+/**
+ * Split **str** into a list of strings, using the **delims** delimiters and output the result in **str_vec**.
+ * 
+ * @param [in] str String to split and save as Vector
+ * @param [in] delims characters used to split **str**
+ * @param [out] str_vec Vector modified containing str after it has been split
+**/
+extern void get_str_vec(const std::string& str,
+                         const char *delims,
+			 std::vector<std::string>& str_vec);
+
+/**
+ * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_list**.
+ * 
+ * @param [in] str String to split and save as Set
+ * @param [out] str_list Set modified containing str after it has been split
+**/
+extern void get_str_set(const std::string& str,
+			std::set<std::string>& str_list);
+
+/**
+ * Split **str** into a list of strings, using the **delims** delimiters and output the result in **str_list**.
+ * 
+ * @param [in] str String to split and save as Set
+ * @param [in] delims characters used to split **str**
+ * @param [out] str_list Set modified containing str after it has been split
+**/
+extern void get_str_set(const std::string& str,
+                        const char *delims,
+			std::set<std::string>& str_list);
+
+/**
+ * Return a String containing the vector **v** joined with **sep**
+ * 
+ * If **v** is empty, the function returns an empty string
+ * For each element in **v**,
+ * it will concatenate this element and **sep** with result
+ * 
+ * @param [in] v Vector to join as a String
+ * @param [in] sep String used to join each element from **v**
+ * @return empty string if **v** is empty or concatenated string
+**/
+inline std::string str_join(const std::vector<std::string>& v, std::string sep)
+{
+  if (v.empty())
+    return std::string();
+  std::vector<std::string>::const_iterator i = v.begin();
+  std::string r = *i;
+  for (++i; i != v.end(); ++i) {
+    r += sep;
+    r += *i;
+  }
+  return r;
+}
+
+#endif

--- a/sim/test_dmclock_main.cc
+++ b/sim/test_dmclock_main.cc
@@ -46,8 +46,8 @@ int main(int argc, char* argv[]) {
     sim::ceph_argparse_early_args(args, &conf_file_list);
 
     sim::sim_config_t g_conf;
-    std::vector<sim::cli_type_t> &cli_type = g_conf.cli_type;
-    std::vector<sim::srv_type_t> &srv_type = g_conf.srv_type;
+    std::vector<sim::cli_group_t> &cli_group = g_conf.cli_group;
+    std::vector<sim::srv_group_t> &srv_group = g_conf.srv_group;
 
     if (!conf_file_list.empty()) {
       int ret;
@@ -57,41 +57,76 @@ int main(int argc, char* argv[]) {
 	_exit(1);
       }
     } else {
-      for (uint i = 0; i < g_conf.server_types; ++i) {
-	sim::srv_type_t st;
-	srv_type.push_back(st);
-      }
-      for (uint i = 0; i < g_conf.client_types; ++i) {
-	sim::cli_type_t ct;
-	cli_type.push_back(ct);
-      }
+      // default simulation parameter
+      g_conf.client_groups = 2;
+
+      sim::srv_group_t st;
+      srv_group.push_back(st);
+
+      sim::cli_group_t ct1(99, 0);
+      cli_group.push_back(ct1);
+
+      sim::cli_group_t ct2(1, 10);
+      cli_group.push_back(ct2);
     }
 
-    const uint server_count = g_conf.server_count;
-    const uint client_count = g_conf.client_count;
-    const uint server_types = g_conf.server_types;
-    const uint client_types = g_conf.client_types;
+    const uint server_groups = g_conf.server_groups;
+    const uint client_groups = g_conf.client_groups;
     const bool server_random_selection = g_conf.server_random_selection;
     const bool server_soft_limit = g_conf.server_soft_limit;
+    uint server_total_count = 0;
+    uint client_total_count = 0;
 
-    std::vector<test::dmc::ClientInfo> client_info;
-    for (uint i = 0; i < client_types; ++i) {
-      client_info.push_back(test::dmc::ClientInfo 
-			  { cli_type[i].client_reservation,
-			    cli_type[i].client_weight,
-			    cli_type[i].client_limit } );
+    for (uint i = 0; i < client_groups; ++i) {
+      client_total_count += cli_group[i].client_count;
     }
 
+    for (uint i = 0; i < server_groups; ++i) {
+      server_total_count += srv_group[i].server_count;
+    }
+
+    std::vector<test::dmc::ClientInfo> client_info;
+    for (uint i = 0; i < client_groups; ++i) {
+      client_info.push_back(test::dmc::ClientInfo 
+			  { cli_group[i].client_reservation,
+			    cli_group[i].client_weight,
+			    cli_group[i].client_limit } );
+    }
+
+    auto ret_client_group_f = [&](const ClientId& c) -> uint {
+      uint group_max = 0;
+      uint i = 0;
+      for (; i < client_groups; ++i) {
+	group_max += cli_group[i].client_count;
+	if (c < group_max) {
+	  break;
+	}
+      }
+      return i;
+    };
+
+    auto ret_server_group_f = [&](const ServerId& s) -> uint {
+      uint group_max = 0;
+      uint i = 0;
+      for (; i < server_groups; ++i) {
+	group_max += srv_group[i].server_count;
+	if (s < group_max) {
+	  break;
+	}
+      }
+      return i;
+    };
+
     auto client_info_f = [=](const ClientId& c) -> test::dmc::ClientInfo {
-        return client_info[c % client_types];
+      return client_info[ret_client_group_f(c)];
     };
 
     auto client_disp_filter = [=] (const ClientId& i) -> bool {
-        return i < 3 || i >= (client_count - 3);
+        return i < 3 || i >= (client_total_count - 3);
     };
 
     auto server_disp_filter = [=] (const ServerId& i) -> bool {
-        return i < 3 || i >= (server_count - 3);
+        return i < 3 || i >= (server_total_count - 3);
     };
 
 
@@ -109,20 +144,20 @@ int main(int argc, char* argv[]) {
     };
 
     std::vector<std::vector<sim::CliInst>> cli_inst;
-    for (uint i = 0; i < client_types; ++i) {
-      if (cli_type[i].client_wait == std::chrono::seconds(0)) {
+    for (uint i = 0; i < client_groups; ++i) {
+      if (cli_group[i].client_wait == std::chrono::seconds(0)) {
 	cli_inst.push_back(
 	    { { sim::req_op, 
-	        (uint16_t)cli_type[i].client_total_ops, 
-	        (double)cli_type[i].client_iops_goal, 
-	        (uint16_t)cli_type[i].client_outstanding_ops } } );
+	        (uint16_t)cli_group[i].client_total_ops, 
+	        (double)cli_group[i].client_iops_goal, 
+	        (uint16_t)cli_group[i].client_outstanding_ops } } );
       } else {
 	cli_inst.push_back(
-	    { { sim::wait_op, cli_type[i].client_wait },
+	    { { sim::wait_op, cli_group[i].client_wait },
 	      { sim::req_op, 
-	        (uint16_t)cli_type[i].client_total_ops, 
-		(double)cli_type[i].client_iops_goal, 
-		(uint16_t)cli_type[i].client_outstanding_ops } } );
+	        (uint16_t)cli_group[i].client_total_ops, 
+		(double)cli_group[i].client_iops_goal, 
+		(uint16_t)cli_group[i].client_outstanding_ops } } );
       }
     }
 
@@ -144,47 +179,48 @@ int main(int argc, char* argv[]) {
         return new test::DmcQueue(client_info_f, can_f, handle_f, server_soft_limit);
     };
 
-  
+ 
     auto create_server_f = [&](ServerId id) -> test::DmcServer* {
+      uint i = ret_server_group_f(id);
       return new test::DmcServer(id,
-                                 srv_type[id % server_types].server_iops, 
-				 srv_type[id % server_types].server_threads,
+                                 srv_group[i].server_iops,
+				 srv_group[i].server_threads,
 				 client_response_f,
 				 test::dmc_server_accumulate_f,
 				 create_queue_f);
     };
 
     auto create_client_f = [&](ClientId id) -> test::DmcClient* {
+      uint i = ret_client_group_f(id);
       test::MySim::ClientBasedServerSelectFunc server_select_f;
-      uint client_server_select_range = cli_type[id % client_types].client_server_select_range;
+      uint client_server_select_range = cli_group[i].client_server_select_range;
       if (!server_random_selection) {
 	server_select_f = simulation->make_server_select_alt_range(client_server_select_range);
       } else {
 	server_select_f = simulation->make_server_select_ran_range(client_server_select_range);
       }
-
       return new test::DmcClient(id,
 				 server_post_f,
 				 std::bind(server_select_f, _1, id),
 				 test::dmc_client_accumulate_f,
-				 cli_inst[id % client_types]);
+				 cli_inst[i]);
     };
 
 #if 1
     std::cout << "[global]" << std::endl << g_conf << std::endl;
-    for (uint i = 0; i < client_types; ++i) {
+    for (uint i = 0; i < client_groups; ++i) {
       std::cout << std::endl << "[client." << i << "]" << std::endl;
-      std::cout << cli_type[i] << std::endl;
+      std::cout << cli_group[i] << std::endl;
     }
-    for (uint i = 0; i < server_types; ++i) {
+    for (uint i = 0; i < server_groups; ++i) {
       std::cout << std::endl << "[server." << i << "]" << std::endl;
-      std::cout << srv_type[i] << std::endl;
+      std::cout << srv_group[i] << std::endl;
     }
     std::cout << std::endl;
 #endif
 
-    simulation->add_servers(server_count, create_server_f);
-    simulation->add_clients(client_count, create_client_f);
+    simulation->add_servers(server_total_count, create_server_f);
+    simulation->add_clients(client_total_count, create_client_f);
 
     simulation->run();
     simulation->display_stats(std::cout,


### PR DESCRIPTION
When executing dmc_sim, configuration filename will be received as parameter so that we could execute multiple tests easily.
For example, for new test with new parameters(like server count, client iops... etc) we just add new configuration file without recompiling.
Moreover we can replay the test just with the configuration file we want to test.

**- Usage**
**1. ./sim/dmc_sim -c/--conf ./dmc_sim.conf (dmclockparameter configuration file)**
**2. dmc_sim.conf(example)**

**[global]**
**server_count= 1**                              _// the total number of servers_
**client_count= 3**                                _// the total number of clients_
**server_types= 1**                              _// types of servers (Ex. server_count=100, server_types=3 >> server i(0~99)‘s type = i% server_types)_
**client_types= 3**                                _// types of clients_
**server_random_selection= false**  _// client’s seed or random server selection way_
**server_soft_limit= false**                  _// allow limit break_

**[client.0]**                                            _// defined as the number of client types_
**client_wait= 0**                                   _// starting waiting time_
**client_total_ops= 10000**                 _// the total number of request per client_
**client_server_select_range= 1**      _// client server selection range_
**client_iops_goal= 1000**                  _// client request issue capacity_
**client_outstanding_ops= 32**          _// client concurrent I/Os_
**client_reservation= 0.0**                   _// tag reservation_
**client_limit= 0.0**                                _// tag limit_
**client_weight= 1.0**                           _// tag weight_

**[client.1]**
**client_wait= 5**
**client_total_ops= 10000**
**client_server_select_range= 1**
**client_iops_goal= 1000**
**client_outstanding_ops= 32**
**client_reservation= 0.0**
**client_limit= 200.0**
**client_weight= 1.0**

**[client.2]**
**client_wait= 10**
**client_total_ops= 10000**
**client_server_select_range= 1**
**client_iops_goal= 1000**
**client_outstanding_ops= 32**
**client_reservation= 0.0**
**client_limit= 250.0**
**client_weight= 2.0**

**[server.0]**                                              _// defined as the number of server types_
**server_iops= 800**                                _// server I/O processing capacity_
**server_threads= 1**                              _// the number of worker threads per server_