### PR TITLE
Large client_total_ops

### DIFF
--- a/sim/src/sim_client.h
+++ b/sim/src/sim_client.h
@@ -36,7 +36,7 @@ namespace crimson {
       union {
 	std::chrono::milliseconds wait_time;
 	struct {
-	  uint16_t count;
+	  uint32_t count;
 	  std::chrono::microseconds time_bw_reqs;
 	  uint16_t max_outstanding;
 	} req_params;
@@ -52,7 +52,7 @@ namespace crimson {
       }
 
       CliInst(req_op_t,
-	      uint16_t count, double ops_per_sec, uint16_t max_outstanding) :
+	      uint32_t count, double ops_per_sec, uint16_t max_outstanding) :
 	op(CliOp::req)
       {
 	args.req_params.count = count;

--- a/sim/src/simulate.h
+++ b/sim/src/simulate.h
@@ -166,7 +166,7 @@ namespace crimson {
 			 [] (const ServerId&) { return true; },
 			 ClientFilter client_filter =
 			 [] (const ClientId&) { return true; },
-			 int head_w = 12, int data_w = 8, int data_prec = 2) {
+			 int head_w = 12, int data_w = 7, int data_prec = 2) {
 	assert(has_run);
 
 	// skip first 2 secondsd of data
@@ -221,7 +221,7 @@ namespace crimson {
 	out << std::setw(head_w) << "client:";
 	for (auto const &c : clients) {
 	  if (!client_filter(c.first)) continue;
-	  out << std::setw(data_w) << c.first;
+	  out << " " << std::setw(data_w) << c.first;
 	}
 	out << std::setw(data_w) << "total" << std::endl;
 
@@ -243,10 +243,10 @@ namespace crimson {
 
 	      if (!client_filter(c.first)) continue;
 
-	      out << std::setw(data_w) << std::setprecision(data_prec) <<
+	      out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
 		std::fixed << data;
 	    }
-	    out << std::setw(data_w) << std::setprecision(data_prec) <<
+	    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
 	      std::fixed << total << std::endl;
 	    ++i;
 	  } while(has_data);
@@ -262,9 +262,9 @@ namespace crimson {
 	out << std::setw(head_w) << "server:";
 	for (auto const &s : servers) {
 	  if (!server_filter(s.first)) continue;
-	  out << std::setw(data_w) << s.first;
+	  out << " " << std::setw(data_w) << s.first;
 	}
-	out << std::setw(data_w) << "total" << std::endl;
+	out << " " << std::setw(data_w) << "total" << std::endl;
 
 	server_out_f(out, this, server_filter, head_w, data_w, data_prec);
 

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -148,14 +148,14 @@ int main(int argc, char* argv[]) {
       if (cli_group[i].client_wait == std::chrono::seconds(0)) {
 	cli_inst.push_back(
 	    { { sim::req_op, 
-	        (uint16_t)cli_group[i].client_total_ops, 
+	        (uint32_t)cli_group[i].client_total_ops,
 	        (double)cli_group[i].client_iops_goal, 
 	        (uint16_t)cli_group[i].client_outstanding_ops } } );
       } else {
 	cli_inst.push_back(
 	    { { sim::wait_op, cli_group[i].client_wait },
 	      { sim::req_op, 
-	        (uint16_t)cli_group[i].client_total_ops, 
+	        (uint32_t)cli_group[i].client_total_ops,
 		(double)cli_group[i].client_iops_goal, 
 		(uint16_t)cli_group[i].client_outstanding_ops } } );
       }

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -243,9 +243,9 @@ void test::client_data(std::ostream& out,
         auto r = client.get_accumulator().reservation_count;
         total_r += r;
         if (!client_disp_filter(i)) continue;
-        out << std::setw(data_w) << r;
+        out << " " << std::setw(data_w) << r;
     }
-    out << std::setw(data_w) << std::setprecision(data_prec) <<
+    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
         std::fixed << total_r << std::endl;
 
     int total_p = 0;
@@ -255,9 +255,9 @@ void test::client_data(std::ostream& out,
         auto p = client.get_accumulator().proportion_count;
         total_p += p;
         if (!client_disp_filter(i)) continue;
-        out << std::setw(data_w) << p;
+        out << " " << std::setw(data_w) << p;
     }
-    out << std::setw(data_w) << std::setprecision(data_prec) <<
+    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
         std::fixed << total_p << std::endl;
 }
 
@@ -273,9 +273,9 @@ void test::server_data(std::ostream& out,
         auto rc = server.get_accumulator().reservation_count;
         total_r += rc;
         if (!server_disp_filter(i)) continue;
-        out << std::setw(data_w) << rc;
+        out << " " << std::setw(data_w) << rc;
     }
-    out << std::setw(data_w) << std::setprecision(data_prec) <<
+    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
         std::fixed << total_r << std::endl;
 
     out << std::setw(head_w) << "prop_ops:";
@@ -285,9 +285,9 @@ void test::server_data(std::ostream& out,
         auto pc = server.get_accumulator().proportion_count;
         total_p += pc;
         if (!server_disp_filter(i)) continue;
-        out << std::setw(data_w) << pc;
+        out << " " << std::setw(data_w) << pc;
     }
-    out << std::setw(data_w) << std::setprecision(data_prec) <<
+    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
         std::fixed << total_p << std::endl;
 
 #ifdef PROFILE


### PR DESCRIPTION
I recently tested large numbers for config parameters for testing high performance device configuration. But, client_total_ops was uint16_t  type. Because it was too small, test didn't work properly.
In this PR, I changed some variables' type from uint16_t to uin32_t. And I fixed output format to print large number properly. Because large numbers with long digits were concatenated with each others without delimiter. It was hard to read the number. Therefore, I added single space between output numbers. But small numbers will be printed same as previous result output because I reduced 'data_w' by 1 for compensation about one added blank.

```
#Test Configuration
[global]
server_groups = 1
client_groups = 1
server_random_selection = false
server_soft_limit = false

[client.0]
client_count = 5
client_wait = 0
client_total_ops = 150000
client_server_select_range = 10
client_iops_goal = 15000
client_outstanding_ops = 64
client_reservation = 20.0
client_limit = 20000.0
client_weight = 1.0

[server.0]
server_count = 16
server_iops = 5500
server_threads = 10
```