### PR TITLE
Indirect Intrusive heap base, and USE_SIMPLE_HEAP flag in dmclock_server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if(PROFILE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPROFILE")
 endif()
 
+if(USE_SIMPLE_PQ)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_SIMPLE_PQ")
+endif()
+
 add_subdirectory(src)
 add_subdirectory(sim)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ When running cmake, set the build type with either:
 To turn on profiling, run cmake with an additional:
 
     -DPROFILE=yes
+    
+To compare current heap implementation with a simple heap (that uses linear search),
+run cmake with an additional:
+
+    -DUSE_SIMPLE_HEAP=yes
 
 ## Running make
 
@@ -37,4 +42,5 @@ priority queue implementations could be added in the future.
 
 ## Using dmclock
 
-To be written....
+Use `./dmc_sim -c config_file` to load parameters from 'config_file' while
+running dmclock simulator. 

--- a/sim/dmc_sim_example.conf
+++ b/sim/dmc_sim_example.conf
@@ -41,3 +41,4 @@ client_weight = 2.0
 server_count = 1
 server_iops = 160
 server_threads = 1
+server_use_heap = true

--- a/sim/dmc_sim_profile.conf
+++ b/sim/dmc_sim_profile.conf
@@ -1,14 +1,14 @@
 [global]
 server_groups = 1
 client_groups = 2
-server_random_selection = true
+server_random_selection = false
 server_soft_limit = true
 
 [client.0]
-client_count = 99
-client_wait = 0
-client_total_ops = 1000
-client_server_select_range = 10
+client_count = 5
+client_wait = 10
+client_total_ops = 100
+client_server_select_range = 1
 client_iops_goal = 50
 client_outstanding_ops = 100
 client_reservation = 20.0
@@ -16,18 +16,18 @@ client_limit = 60.0
 client_weight = 1.0
 
 [client.1]
-client_count = 1
-client_wait = 10
-client_total_ops = 1000
-client_server_select_range = 10
+client_count = 3
+client_wait = 0
+client_total_ops = 100
+client_server_select_range = 1
 client_iops_goal = 50
 client_outstanding_ops = 100
-client_reservation = 20.0
+client_reservation = 0.0
 client_limit = 60.0
 client_weight = 1.0
 
 [server.0]
-server_count = 100
-server_iops = 40
+server_count = 1
+server_iops = 50
 server_threads = 1
 server_use_heap = true

--- a/sim/src/config.cc
+++ b/sim/src/config.cc
@@ -140,6 +140,8 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
       st.server_iops = std::stoul(val);
     if (!cf.read(section, "server_threads", val))
       st.server_threads = std::stoul(val);
+    if (!cf.read(section, "server_use_heap", val))
+      st.server_use_heap = stobool(val);
     g_conf.srv_group.push_back(st);
   }
 

--- a/sim/src/config.h
+++ b/sim/src/config.h
@@ -73,13 +73,15 @@ namespace crimson {
       uint server_count;
       uint server_iops;
       uint server_threads;
+      bool server_use_heap;
 
       srv_group_t(uint _server_count = 100,
 		  uint _server_iops = 40,
 		  uint _server_threads = 1) :
 	server_count(_server_count),
 	server_iops(_server_iops),
-	server_threads(_server_threads)
+	server_threads(_server_threads),
+	server_use_heap (true)
       {
 	// empty
       }
@@ -89,7 +91,8 @@ namespace crimson {
 	out <<
 	  "server_count = " << srv_group.server_count << "\n" <<
 	  "server_iops = " << srv_group.server_iops << "\n" <<
-	  "server_threads = " << srv_group.server_threads;
+	  "server_threads = " << srv_group.server_threads << "\n" <<
+	  "server_use_heap = " << srv_group.server_use_heap;
 	return out;
       }
     }; // class srv_group_t

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
                                                            server_id,
                                                            phase);
     };
-
+    // server_use_heap
     test::CreateQueueF create_queue_f =
         [&](test::DmcQueue::CanHandleRequestFunc can_f,
             test::DmcQueue::HandleRequestFunc handle_f) -> test::DmcQueue* {

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -775,7 +775,7 @@ namespace crimson {
 #endif
 
 	resv_heap.demote(top);
-	limit_heap.demote(top);
+	limit_heap.adjust(top);
 #if USE_PROP_HEAP
 	prop_heap.demote(top);
 #endif

--- a/support/src/indirect_intrusive_base.h
+++ b/support/src/indirect_intrusive_base.h
@@ -1,0 +1,370 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Copyright (C) 2016 Red Hat Inc.
+ */
+
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <functional>
+
+#include "assert.h"
+
+
+namespace crimson {
+  using IndIntruHeapData = size_t;
+
+  /* T is the ultimate data that's being stored in the heap, although
+   *   through indirection.
+   *
+   * I is the indirect type that will actually be stored in the heap
+   *   and that must allow dereferencing (via operator*) to yield a
+   *   T&.
+   *
+   * C is functor when given two T&'s will return true if the first
+   *   must precede the second.
+   *
+   * heap_info is a data member pointer as to where the heap data in T
+   * is stored.
+   */
+  template<typename I, typename T, IndIntruHeapData T::*heap_info,  typename C>
+  class IndIntruBase {
+
+    static_assert(
+      std::is_same<T,typename std::pointer_traits<I>::element_type>::value,
+      "class I must resolve to class T by indirection (pointer dereference)");
+
+    static_assert(
+      std::is_same<bool,
+      typename std::result_of<C(const T&,const T&)>::type>::value,
+      "class C must define operator() to take two const T& and return a bool");
+
+  protected:
+
+    class Iterator {
+      friend IndIntruBase<I, T, heap_info, C>;
+
+      IndIntruBase<I, T, heap_info, C>& heap;
+      size_t                            index;
+
+      Iterator(IndIntruBase<I, T, heap_info, C>& _heap, size_t _index) :
+	heap(_heap),
+	index(_index)
+      {
+	// empty
+      }
+
+    public:
+
+      Iterator(Iterator&& other) :
+	heap(other.heap),
+	index(other.index)
+      {
+	// empty
+      }
+
+      Iterator(const Iterator& other) :
+	heap(other.heap),
+	index(other.index)
+      {
+	// empty
+      }
+
+      Iterator& operator=(Iterator&& other) {
+	std::swap(heap, other.heap);
+	std::swap(index, other.index);
+	return *this;
+      }
+
+      Iterator& operator=(const Iterator& other) {
+	heap = other.heap;
+	index = other.index;
+      }
+
+      Iterator& operator++() {
+	if (index <= heap.count) {
+	  ++index;
+	}
+	return *this;
+      }
+
+      bool operator==(const Iterator& other) const {
+	return index == other.index;
+      }
+
+      bool operator!=(const Iterator& other) const {
+	return !(*this == other);
+      }
+
+      T& operator*() {
+	return *heap.data[index];
+      }
+
+      T* operator->() {
+	return &(*heap.data[index]);
+      }
+
+#if 0
+      // the item this iterator refers to
+      void increase() {
+	heap.siftUp(index);
+      }
+#endif
+    }; // class Iterator
+
+
+    class ConstIterator {
+      friend IndIntruBase<I, T, heap_info, C>;
+
+      const IndIntruBase<I, T, heap_info, C>& heap;
+      size_t                                  index;
+
+      ConstIterator(const IndIntruBase<I, T, heap_info, C>& _heap, size_t _index) :
+	heap(_heap),
+	index(_index)
+      {
+	// empty
+      }
+
+    public:
+
+      ConstIterator(ConstIterator&& other) :
+	heap(other.heap),
+	index(other.index)
+      {
+	// empty
+      }
+
+      ConstIterator(const ConstIterator& other) :
+	heap(other.heap),
+	index(other.index)
+      {
+	// empty
+      }
+
+      ConstIterator& operator=(ConstIterator&& other) {
+	std::swap(heap, other.heap);
+	std::swap(index, other.index);
+	return *this;
+      }
+
+      ConstIterator& operator=(const ConstIterator& other) {
+	heap = other.heap;
+	index = other.index;
+      }
+
+      ConstIterator& operator++() {
+	if (index <= heap.count) {
+	  ++index;
+	}
+	return *this;
+      }
+
+      bool operator==(const ConstIterator& other) const {
+	return &heap == &other.heap && index == other.index;
+      }
+
+      bool operator!=(const ConstIterator& other) const {
+	return !(*this == other);
+      }
+
+      const T& operator*() {
+	return *heap.data[index];
+      }
+
+      const T* operator->() {
+	return &(*heap.data[index]);
+      }
+
+    }; // class ConstIterator
+
+
+  protected:
+    using index_t = IndIntruHeapData;
+
+    std::vector<I> data;
+    index_t        count;
+
+
+  public:
+
+    IndIntruBase() :
+      count(0)
+    {
+      // empty
+    }
+
+    IndIntruBase(const IndIntruBase<I,T,heap_info, C>& other) :
+      count(other.count)
+    {
+      for (uint i = 0; i < other.count; ++i) {
+	data.push_back(other.data[i]);
+      }
+    }
+
+    bool empty() const { return 0 == count; }
+
+    size_t size() const { return count; }
+
+    T& top() { return *data[0]; }
+
+    const T& top() const { return *data[0]; }
+
+    I& top_ind() { return data[0]; }
+
+    const I& top_ind() const { return data[0]; }
+
+    Iterator find(const I& item) {
+      for (index_t i = 0; i < count; ++i) {
+	if (data[i] == item) {
+	  return Iterator(*this, i);
+	}
+      }
+      return end();
+    }
+
+    // NB: should we be using operator== instead of address check?
+    Iterator find(const T& item) {
+      for (index_t i = 0; i < count; ++i) {
+	if (data[i].get() == &item) {
+	  return Iterator(*this, i);
+	}
+      }
+      return end();
+    }
+
+    // reverse find -- start looking from bottom of heap
+    Iterator rfind(const I& item) {
+      // index_t is unsigned, so we can't allow to go negative; so
+      // we'll keep it one more than actual index
+      for (index_t i = count; i > 0; --i) {
+	if (data[i-1] == item) {
+	  return Iterator(*this, i-1);
+	}
+      }
+      return end();
+    }
+
+    // reverse find -- start looking from bottom of heap
+    Iterator rfind(const T& item) {
+      // index_t is unsigned, so we can't allow to go negative; so
+      // we'll keep it one more than actual index
+      for (index_t i = count; i > 0; --i) {
+	if (data[i-1].get() == &item) {
+	  return Iterator(*this, i-1);
+	}
+      }
+      return end();
+    }
+
+    Iterator begin() {
+      return Iterator(*this, 0);
+    }
+
+    Iterator end() {
+      return Iterator(*this, count);
+    }
+
+    ConstIterator cbegin() const {
+      return ConstIterator(*this, 0);
+    }
+
+    ConstIterator cend() const {
+      return ConstIterator(*this, count);
+    }
+
+    // queue methods
+    void push(I&& item) {
+      index_t i = count++;
+      intru_data_of(item) = i;
+      data.emplace_back(std::move(item));
+    }
+
+    void push(const I& item) {
+      I copy(item);
+      push(std::move(copy));
+    }
+
+    void pop() {
+      remove((index_t)0);
+    }
+
+    size_t remove(Iterator& i) {
+      size_t _index = i.index;
+      remove(_index);
+      i = end();
+      return _index;
+    }
+
+    size_t remove(const I& item) {
+      index_t i = (*item).*heap_info;
+      remove(i);
+      return i;
+    }
+
+    friend std::ostream& operator<<(std::ostream& out, const IndIntruBase& h) {
+      auto i = h.data.cbegin();
+      if (i != h.data.cend()) {
+	out << **i;
+	++i;
+	while (i != h.data.cend()) {
+	  out << ", " << **i;
+	}
+      }
+      return out;
+    }
+
+    // default value of filter parameter to display_sorted
+    static bool all_filter(const T& data) { return true; }
+
+    // can only be called if I is copyable
+    std::ostream&
+    display_sorted(std::ostream& out,
+		   std::function<bool(const T&)> filter = all_filter) const {
+      static_assert(std::is_copy_constructible<I>::value,
+		    "cannot call display_sorted when class I is not copy"
+		    " constructible");
+
+      IndIntruBase<I,T,heap_info, C> copy = *this;
+
+      bool first = true;
+      while(!copy.empty()) {
+	const T& top = copy.top();
+	if (filter(top)) {
+	  if (!first) {
+	    out << ", ";
+	  }
+	  out << copy.top();
+	  first = false;
+	}
+	copy.pop();
+      }
+
+      return out;
+    }
+
+    ~IndIntruBase() {
+      // empty
+    };
+
+
+  protected:
+
+    static index_t& intru_data_of(I& item) {
+      return (*item).*heap_info;
+    }
+
+    void remove(index_t i) {
+      std::swap(data[i], data[--count]);
+      intru_data_of(data[i]) = i;
+      data.pop_back();
+    }
+
+  }; // class IndIntruBase
+} // namespace crimson

--- a/support/src/indirect_intrusive_heap.h
+++ b/support/src/indirect_intrusive_heap.h
@@ -8,279 +8,46 @@
 
 #pragma once
 
-
-#include <memory>
-#include <vector>
-#include <string>
-#include <iostream>
-#include <functional>
-
-#include "assert.h"
+#include "indirect_intrusive_base.h"
 
 
 namespace crimson {
-  using IndIntruHeapData = size_t;
 
-  /* T is the ultimate data that's being stored in the heap, although
-   *   through indirection.
-   *
-   * I is the indirect type that will actually be stored in the heap
-   *   and that must allow dereferencing (via operator*) to yield a
-   *   T&.
-   *
-   * C is a functor when given two T&'s will return true if the first
-   *   must precede the second.
-   *
-   * heap_info is a data member pointer as to where the heap data in T
-   * is stored.
-   */
   template<typename I, typename T, IndIntruHeapData T::*heap_info, typename C>
-  class IndIntruHeap {
+  class IndIntruHeap : public IndIntruBase <I, T, heap_info, C> {
+    using super = IndIntruBase <I, T, heap_info, C>;
 
-    static_assert(
-      std::is_same<T,typename std::pointer_traits<I>::element_type>::value,
-      "class I must resolve to class T by indirection (pointer dereference)");
-
-    static_assert(
-      std::is_same<bool,
-      typename std::result_of<C(const T&,const T&)>::type>::value,
-      "class C must define operator() to take two const T& and return a bool");
-
-
-    class Iterator {
-      friend IndIntruHeap<I, T, heap_info, C>;
-
-      IndIntruHeap<I, T, heap_info, C>& heap;
-      size_t                            index;
-
-      Iterator(IndIntruHeap<I, T, heap_info, C>& _heap, size_t _index) :
-	heap(_heap),
-	index(_index)
-      {
-	// empty
-      }
-
-    public:
-
-      Iterator(Iterator&& other) :
-	heap(other.heap),
-	index(other.index)
-      {
-	// empty
-      }
-
-      Iterator(const Iterator& other) :
-	heap(other.heap),
-	index(other.index)
-      {
-	// empty
-      }
-
-      Iterator& operator=(Iterator&& other) {
-	std::swap(heap, other.heap);
-	std::swap(index, other.index);
-	return *this;
-      }
-
-      Iterator& operator=(const Iterator& other) {
-	heap = other.heap;
-	index = other.index;
-      }
-
-      Iterator& operator++() {
-	if (index <= heap.count) {
-	  ++index;
-	}
-	return *this;
-      }
-
-      bool operator==(const Iterator& other) const {
-	return index == other.index;
-      }
-
-      bool operator!=(const Iterator& other) const {
-	return !(*this == other);
-      }
-
-      T& operator*() {
-	return *heap.data[index];
-      }
-
-      T* operator->() {
-	return &(*heap.data[index]);
-      }
-
-#if 0
-      // the item this iterator refers to
-      void increase() {
-	heap.siftUp(index);
-      }
-#endif
-    }; // class Iterator
-
-    
-    class ConstIterator {
-      friend IndIntruHeap<I, T, heap_info, C>;
-
-      const IndIntruHeap<I, T, heap_info, C>& heap;
-      size_t                                  index;
-
-      ConstIterator(const IndIntruHeap<I, T, heap_info, C>& _heap, size_t _index) :
-	heap(_heap),
-	index(_index)
-      {
-	// empty
-      }
-
-    public:
-
-      ConstIterator(ConstIterator&& other) :
-	heap(other.heap),
-	index(other.index)
-      {
-	// empty
-      }
-
-      ConstIterator(const ConstIterator& other) :
-	heap(other.heap),
-	index(other.index)
-      {
-	// empty
-      }
-
-      ConstIterator& operator=(ConstIterator&& other) {
-	std::swap(heap, other.heap);
-	std::swap(index, other.index);
-	return *this;
-      }
-
-      ConstIterator& operator=(const ConstIterator& other) {
-	heap = other.heap;
-	index = other.index;
-      }
-
-      ConstIterator& operator++() {
-	if (index <= heap.count) {
-	  ++index;
-	}
-	return *this;
-      }
-
-      bool operator==(const ConstIterator& other) const {
-	return &heap == &other.heap && index == other.index;
-      }
-
-      bool operator!=(const ConstIterator& other) const {
-	return !(*this == other);
-      }
-
-      const T& operator*() {
-	return *heap.data[index];
-      }
-
-      const T* operator->() {
-	return &(*heap.data[index]);
-      }
-    }; // class ConstIterator
-
-    
   protected:
     using index_t = IndIntruHeapData;
 
-    std::vector<I> data;
-    index_t        count;
     C              comparator;
 
   public:
 
     IndIntruHeap() :
-      count(0)
+      super()
     {
       // empty
     }
 
-    IndIntruHeap(const IndIntruHeap<I,T,heap_info,C>& other) :
-      count(other.count)
+    IndIntruHeap(const IndIntruHeap < I, T, heap_info, C > &other) :
+      super (other)
     {
-      for (uint i = 0; i < other.count; ++i) {
-	data.push_back(other.data[i]);
-      }
+      // empty
     }
 
-    bool empty() const { return 0 == count; }
-
-    size_t size() const { return count; }
-
-    T& top() { return *data[0]; }
-
-    const T& top() const { return *data[0]; }
-
-    I& top_ind() { return data[0]; }
-
-    const I& top_ind() const { return data[0]; }
+    void pop() {
+      remove((index_t)0);
+    }
 
     void push(I&& item) {
-      index_t i = count++;
-      intru_data_of(item) = i;
-      data.emplace_back(std::move(item));
-      sift_up(i);
+      super::push(std::move(item));
+      sift_up(super::count - 1);
     }
 
     void push(const I& item) {
       I copy(item);
       push(std::move(copy));
-    }
-
-    void pop() {
-      remove(0);
-    }
-
-    void remove(Iterator& i) {
-      remove(i.index);
-      i = end();
-    }
-
-    Iterator find(const I& item) {
-      for (index_t i = 0; i < count; ++i) {
-	if (data[i] == item) {
-	  return Iterator(*this, i);
-	}
-      }
-      return end();
-    }
-
-    // NB: should we be using operator== instead of address check?
-    Iterator find(const T& item) {
-      for (index_t i = 0; i < count; ++i) {
-	if (data[i].get() == &item) {
-	  return Iterator(*this, i);
-	}
-      }
-      return end();
-    }
-
-    // reverse find -- start looking from bottom of heap
-    Iterator rfind(const I& item) {
-      // index_t is unsigned, so we can't allow to go negative; so
-      // we'll keep it one more than actual index
-      for (index_t i = count; i > 0; --i) {
-	if (data[i-1] == item) {
-	  return Iterator(*this, i-1);
-	}
-      }
-      return end();
-    }
-
-    // reverse find -- start looking from bottom of heap
-    Iterator rfind(const T& item) {
-      // index_t is unsigned, so we can't allow to go negative; so
-      // we'll keep it one more than actual index
-      for (index_t i = count; i > 0; --i) {
-	if (data[i-1].get() == &item) {
-	  return Iterator(*this, i-1);
-	}
-      }
-      return end();
     }
 
     void promote(T& item) {
@@ -295,76 +62,26 @@ namespace crimson {
       sift(item.*heap_info);
     }
 
-    Iterator begin() {
-      return Iterator(*this, 0);
+    void remove(typename super::Iterator& i) {
+      index_t _i = super::remove(i);
+      sift_down(_i);
     }
 
-    Iterator end() {
-      return Iterator(*this, count);
-    }
-
-    ConstIterator cbegin() const {
-      return ConstIterator(*this, 0);
-    }
-
-    ConstIterator cend() const {
-      return ConstIterator(*this, count);
-    }
-
-    friend std::ostream& operator<<(std::ostream& out, const IndIntruHeap& h) {
-      auto i = h.data.cbegin();
-      if (i != h.data.cend()) {
-	out << **i;
-	++i;
-	while (i != h.data.cend()) {
-	  out << ", " << **i;
-	}
-      }
-      return out;
-    }
-
-    // can only be called if I is copyable
-    std::ostream&
-    display_sorted(std::ostream& out,
-		   std::function<bool(const T&)> filter = all_filter) const {
-      static_assert(std::is_copy_constructible<I>::value,
-		    "cannot call display_sorted when class I is not copy"
-		    " constructible");
-
-      IndIntruHeap<I,T,heap_info,C> copy = *this;
-
-      bool first = true;
-      while(!copy.empty()) {
-	const T& top = copy.top();
-	if (filter(top)) {
-	  if (!first) {
-	    out << ", ";
-	  }
-	  out << copy.top();
-	  first = false;
-	}
-	copy.pop();
-      }
-
-      return out;
-    }
-
-
-  protected:
-
-    static index_t& intru_data_of(I& item) {
-      return (*item).*heap_info;
-    }
-
-    void remove(index_t i) {
-      std::swap(data[i], data[--count]);
-      intru_data_of(data[i]) = i;
-      data.pop_back();
+    void remove(const I& item) {
+      size_t i = super::remove(item);
       sift_down(i);
     }
 
-    // default value of filter parameter to display_sorted
-    static bool all_filter(const T& data) { return true; }
+    ~IndIntruHeap() {
+       // empty
+    }
+
+  protected:
+
+    void remove(index_t i) {
+      super::remove(i);
+      sift_down(i);
+    }
 
     // when i is negative?
     static inline index_t parent(index_t i) {
@@ -379,39 +96,39 @@ namespace crimson {
     void sift_up(index_t i) {
       while (i > 0) {
 	index_t pi = parent(i);
-	if (!comparator(*data[i], *data[pi])) {
+	if (!comparator(*super::data[i], *super::data[pi])) {
 	  break;
 	}
 
-	std::swap(data[i], data[pi]);
-	intru_data_of(data[i]) = i;
-	intru_data_of(data[pi]) = pi;
+	std::swap(super::data[i], super::data[pi]);
+	super::intru_data_of(super::data[i]) = i;
+	super::intru_data_of(super::data[pi]) = pi;
 	i = pi;
       }
     } // sift_up
 
     void sift_down(index_t i) {
-      while (i < count) {
+      while (i < super::count) {
 	index_t li = lhs(i);
 	index_t ri = rhs(i);
 
-	if (li < count) {
-	  if (comparator(*data[li], *data[i])) {
-	    if (ri < count && comparator(*data[ri], *data[li])) {
-	      std::swap(data[i], data[ri]);
-	      intru_data_of(data[i]) = i;
-	      intru_data_of(data[ri]) = ri;
+	if (li < super::count) {
+	  if (comparator(*super::data[li], *super::data[i])) {
+	    if (ri < super::count && comparator(*super::data[ri], *super::data[li])) {
+	      std::swap(super::data[i], super::data[ri]);
+	      super::intru_data_of(super::data[i]) = i;
+	      super::intru_data_of(super::data[ri]) = ri;
 	      i = ri;
 	    } else {
-	      std::swap(data[i], data[li]);
-	      intru_data_of(data[i]) = i;
-	      intru_data_of(data[li]) = li;
+	      std::swap(super::data[i], super::data[li]);
+	      super::intru_data_of(super::data[i]) = i;
+	      super::intru_data_of(super::data[li]) = li;
 	      i = li;
 	    }
-	  } else if (ri < count && comparator(*data[ri], *data[i])) {
-	    std::swap(data[i], data[ri]);
-	    intru_data_of(data[i]) = i;
-	    intru_data_of(data[ri]) = ri;
+	  } else if (ri < super::count && comparator(*super::data[ri], *super::data[i])) {
+	    std::swap(super::data[i], super::data[ri]);
+	    super::intru_data_of(super::data[i]) = i;
+	    super::intru_data_of(super::data[ri]) = ri;
 	    i = ri;
 	  } else {
 	    break;
@@ -428,7 +145,7 @@ namespace crimson {
 	sift_down(i);
       } else {
 	index_t pi = parent(i);
-	if (comparator(*data[i], *data[pi])) {
+	if (comparator(*super::data[i], *super::data[pi])) {
 	  // if we can go up, we will
 	  sift_up(i);
 	} else {
@@ -437,5 +154,6 @@ namespace crimson {
 	}
       }
     } // sift
+
   }; // class IndIntruHeap
 } // namespace crimson

--- a/support/src/indirect_intrusive_simple_pq.h
+++ b/support/src/indirect_intrusive_simple_pq.h
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Copyright (C) 2016 Red Hat Inc.
+ */
+
+
+#pragma once
+
+#include "indirect_intrusive_base.h"
+
+
+namespace crimson {
+
+  template<typename I, typename T, IndIntruHeapData T::*heap_info, typename C>
+  class IndIntruSimplePQ : public IndIntruBase <I, T, heap_info, C>  {
+    using super = IndIntruBase <I, T, heap_info, C>;
+
+  protected:
+    using index_t = IndIntruHeapData;
+
+    C               comparator;
+    T               *dummy_ref;
+    index_t         min_index;
+
+  public:
+
+    IndIntruSimplePQ() :
+      super(),
+      dummy_ref(NULL),
+      min_index(0)
+    {
+      // empty
+    }
+
+    IndIntruSimplePQ(const IndIntruSimplePQ < I, T, heap_info, C > &other) :
+      super(other),
+      dummy_ref(NULL),
+      min_index(other.min_index)
+    {
+      // empty
+    }
+
+    void pop() {
+      remove((index_t)0);
+    }
+
+    void push(I&& item) {
+      super::push(std::move(item));
+      adjust(*dummy_ref);
+    }
+
+    void push(const I& item) {
+      I copy(item);
+      push(std::move(copy));
+    }
+
+    void promote(T& item) {
+      adjust(item);
+    }
+
+    void demote(T& item) {
+      adjust(item);
+    }
+
+    // ignore the parameter
+    void adjust(T& ) {
+      min_index = 0;
+      for (index_t i = 1 ; i < super::count; i++){
+	if (comparator(*super::data[i], *super::data[min_index])){
+	  min_index = i;
+	}
+      }
+      if (min_index) {
+	std::swap(super::data[0], super::data[min_index]);
+	super::intru_data_of(super::data[0]) = 0;
+	super::intru_data_of(super::data[min_index]) = min_index;
+      }
+    }
+
+    void remove(typename super::Iterator& i) {
+      super::remove(i);
+      adjust(*dummy_ref);
+    }
+
+    void remove(const I& item) {
+      super::remove(item);
+      adjust(*dummy_ref);
+    }
+
+  protected:
+
+    void remove(index_t i) {
+      super::remove(i);
+      adjust(*dummy_ref);
+    }
+
+  }; // class IndIntruSimplePQ
+
+} // namespace crimson

--- a/support/test/CMakeLists.txt
+++ b/support/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(srcs
   test_intrusive_heap.cc)
 add_executable(test_intru_heap test_intrusive_heap.cc)
 
-set(test_srcs test_indirect_intrusive_heap.cc)
+set(test_srcs test_indirect_intrusive_heap.cc test_indirect_intrusive_simple_pq.cc test_indirect_intrusive_base.cc)
 
 set_source_files_properties(${srcs} ${test_srcs}
   PROPERTIES
@@ -19,12 +19,12 @@ set_source_files_properties(${srcs} ${test_srcs}
 
 add_executable(data-struct-tests EXCLUDE_FROM_ALL ${test_srcs})
 
-set_target_properties(data-struct-tests
+set_target_properties(data-struct-tests 
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ../../test)
 
 target_link_libraries(data-struct-tests
-  PUBLIC pthread ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
+  PUBLIC ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread )
 
 # for every argument, adds a test with that name, using it as a gtest filter
 function(make_tests)

--- a/support/test/test_indirect_intrusive_base.cc
+++ b/support/test/test_indirect_intrusive_base.cc
@@ -1,0 +1,204 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Copyright (C) 2016 Red Hat Inc.
+ */
+
+#include <iostream>
+#include <memory>
+#include <set>
+
+#include "gtest/gtest.h"
+
+#include "indirect_intrusive_base.h"
+
+
+struct Elem {
+  int data;
+
+  crimson::IndIntruHeapData heap_data;
+  crimson::IndIntruHeapData heap_data_alt;
+
+  Elem(int _data) : data(_data) { }
+
+  friend std::ostream& operator<<(std::ostream& out, const Elem& d) {
+    out << d.data;
+    return out;
+  }
+};
+
+
+// sorted low to high
+struct ElemCompare {
+  bool operator()(const Elem& d1, const Elem& d2) {
+    return d1.data < d2.data;
+  }
+};
+
+
+class HeapFixture3: public ::testing::Test {
+
+public:
+
+  crimson::IndIntruBase<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  std::shared_ptr<Elem> data1, data2, data3, data4, data5, data6, data7;
+
+  void SetUp() {
+    data1 = std::make_shared<Elem>(2);
+    data2 = std::make_shared<Elem>(99);
+    data3 = std::make_shared<Elem>(1);
+    data4 = std::make_shared<Elem>(-5);
+    data5 = std::make_shared<Elem>(12);
+    data6 = std::make_shared<Elem>(-12);
+    data7 = std::make_shared<Elem>(-7);
+
+    heap.push(data1);
+    heap.push(data2);
+    heap.push(data3);
+    heap.push(data4);
+    heap.push(data5);
+    heap.push(data6);
+    heap.push(data7);
+  }
+
+  void TearDown() { 
+    // nothing to do
+  }
+}; // class HeapFixture3
+
+
+TEST(IndIntruBase, shared_ptr) {
+  crimson::IndIntruBase<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(std::make_shared<Elem>(2));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(std::make_shared<Elem>(99));
+  heap.push(std::make_shared<Elem>(1));
+  heap.push(std::make_shared<Elem>(-5));
+  heap.push(std::make_shared<Elem>(12));
+  heap.push(std::make_shared<Elem>(-12));
+  heap.push(std::make_shared<Elem>(-7));
+
+  EXPECT_FALSE(heap.empty());
+
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+
+
+TEST(IndIntruBase, unique_ptr) {
+  crimson::IndIntruBase<std::unique_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(std::unique_ptr<Elem>(new Elem(2)));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(std::unique_ptr<Elem>(new Elem(99)));
+  heap.push(std::unique_ptr<Elem>(new Elem(1)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-5)));
+  heap.push(std::unique_ptr<Elem>(new Elem(12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-7)));
+
+  EXPECT_FALSE(heap.empty());
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+
+
+TEST(IndIntruBase, regular_ptr) {
+  crimson::IndIntruBase<Elem*, Elem, &Elem::heap_data, ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(new Elem(2));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(new Elem(99));
+  heap.push(new Elem(1));
+  heap.push(new Elem(-5));
+  heap.push(new Elem(12));
+  heap.push(new Elem(-12));
+  heap.push(new Elem(-7));
+
+  EXPECT_FALSE(heap.empty());
+
+  EXPECT_EQ(2, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(-7, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(-12, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(12, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(-5, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(1, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+
+  EXPECT_EQ(99, heap.top().data);
+  delete &heap.top();
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+

--- a/support/test/test_indirect_intrusive_simple_pq.cc
+++ b/support/test/test_indirect_intrusive_simple_pq.cc
@@ -1,0 +1,574 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+/*
+ * Copyright (C) 2016 Red Hat Inc.
+ */
+
+#include <iostream>
+#include <memory>
+#include <set>
+
+#include "gtest/gtest.h"
+
+#include "indirect_intrusive_simple_pq.h"
+
+
+struct Elem {
+  int data;
+
+  crimson::IndIntruHeapData heap_data;
+  crimson::IndIntruHeapData heap_data_alt;
+
+  Elem(int _data) : data(_data) { }
+
+  friend std::ostream& operator<<(std::ostream& out, const Elem& d) {
+    out << d.data;
+    return out;
+  }
+};
+
+
+// sorted low to high
+struct ElemCompare {
+  bool operator()(const Elem& d1, const Elem& d2) {
+    return d1.data < d2.data;
+  }
+};
+
+
+// first all evens precede all odds, then they're sorted high to low
+struct ElemCompareAlt {
+  bool operator()(const Elem& d1, const Elem& d2) {
+    if (0 == d1.data % 2) {
+      if (0 == d2.data % 2) {
+	return d1.data > d2.data;
+      } else {
+	return true;
+      }
+    } else if (0 == d2.data % 2) {
+      return false;
+    } else {
+      return d1.data > d2.data;
+    }
+  }
+};
+
+
+class HeapFixture2: public ::testing::Test {
+
+public:
+
+  crimson::IndIntruSimplePQ<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  std::shared_ptr<Elem> data1, data2, data3, data4, data5, data6, data7;
+
+  void SetUp() {
+    data1 = std::make_shared<Elem>(2);
+    data2 = std::make_shared<Elem>(99);
+    data3 = std::make_shared<Elem>(1);
+    data4 = std::make_shared<Elem>(-5);
+    data5 = std::make_shared<Elem>(12);
+    data6 = std::make_shared<Elem>(-12);
+    data7 = std::make_shared<Elem>(-7);
+
+    heap.push(data1);
+    heap.push(data2);
+    heap.push(data3);
+    heap.push(data4);
+    heap.push(data5);
+    heap.push(data6);
+    heap.push(data7);
+  }
+
+  void TearDown() { 
+    // nothing to do
+  }
+}; // class HeapFixture2
+
+
+TEST(IndIntruSimplePQ, shared_ptr) {
+  crimson::IndIntruSimplePQ<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(std::make_shared<Elem>(2));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(std::make_shared<Elem>(99));
+  heap.push(std::make_shared<Elem>(1));
+  heap.push(std::make_shared<Elem>(-5));
+  heap.push(std::make_shared<Elem>(12));
+  heap.push(std::make_shared<Elem>(-12));
+  heap.push(std::make_shared<Elem>(-7));
+
+  // std::cout << heap << std::endl;
+
+  EXPECT_FALSE(heap.empty());
+
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+
+
+TEST(IndIntruSimplePQ, unique_ptr) {
+  crimson::IndIntruSimplePQ<std::unique_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(std::unique_ptr<Elem>(new Elem(2)));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(std::unique_ptr<Elem>(new Elem(99)));
+  heap.push(std::unique_ptr<Elem>(new Elem(1)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-5)));
+  heap.push(std::unique_ptr<Elem>(new Elem(12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-7)));
+
+  EXPECT_FALSE(heap.empty());
+
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+
+
+TEST(IndIntruSimplePQ, regular_ptr) {
+  crimson::IndIntruSimplePQ<Elem*, Elem, &Elem::heap_data, ElemCompare> heap;
+
+  EXPECT_TRUE(heap.empty());
+
+  heap.push(new Elem(2));
+
+  EXPECT_FALSE(heap.empty());
+
+  heap.push(new Elem(99));
+  heap.push(new Elem(1));
+  heap.push(new Elem(-5));
+  heap.push(new Elem(12));
+  heap.push(new Elem(-12));
+  heap.push(new Elem(-7));
+
+  EXPECT_FALSE(heap.empty());
+
+  EXPECT_EQ(-12, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(2, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  delete &heap.top();
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  delete &heap.top();
+
+  EXPECT_FALSE(heap.empty());
+  heap.pop();
+  EXPECT_TRUE(heap.empty());
+}
+
+
+TEST(IndIntruSimplePQ, demote) {
+  crimson::IndIntruSimplePQ<std::unique_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  heap.push(std::unique_ptr<Elem>(new Elem(2)));
+  heap.push(std::unique_ptr<Elem>(new Elem(99)));
+  heap.push(std::unique_ptr<Elem>(new Elem(1)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-5)));
+  heap.push(std::unique_ptr<Elem>(new Elem(12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-7)));
+
+  heap.top().data = 24;
+
+  heap.demote(heap.top());
+
+  EXPECT_EQ(-7, heap.top().data);
+
+  heap.pop();
+  heap.pop();
+  heap.pop();
+  heap.pop();
+  heap.pop();
+
+  EXPECT_EQ(24, heap.top().data);
+}
+
+
+TEST(IndIntruSimplePQ, demote_not) {
+  crimson::IndIntruSimplePQ<std::unique_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  heap.push(std::unique_ptr<Elem>(new Elem(2)));
+  heap.push(std::unique_ptr<Elem>(new Elem(99)));
+  heap.push(std::unique_ptr<Elem>(new Elem(1)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-5)));
+  heap.push(std::unique_ptr<Elem>(new Elem(12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-12)));
+  heap.push(std::unique_ptr<Elem>(new Elem(-7)));
+
+  heap.top().data = -99;
+
+  heap.demote(heap.top());
+
+  EXPECT_EQ(-99, heap.top().data);
+
+  heap.pop();
+
+  EXPECT_EQ(-7, heap.top().data);
+}
+
+
+TEST(IndIntruSimplePQ, promote_and_demote) {
+  crimson::IndIntruSimplePQ<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  auto data1 = std::make_shared<Elem>(1);
+
+  heap.push(std::make_shared<Elem>(2));
+  heap.push(std::make_shared<Elem>(99));
+  heap.push(data1);
+  heap.push(std::make_shared<Elem>(-5));
+  heap.push(std::make_shared<Elem>(12));
+  heap.push(std::make_shared<Elem>(-12));
+  heap.push(std::make_shared<Elem>(-7));
+
+  EXPECT_EQ(-12, heap.top().data);
+
+  data1->data = -99;
+  heap.promote(*data1);
+
+  EXPECT_EQ(-99, heap.top().data);
+
+  data1->data = 999;
+  heap.demote(*data1);
+
+  EXPECT_EQ(-12, heap.top().data);
+
+  data1->data = 9;
+  heap.promote(*data1);
+
+  heap.pop(); // remove -12
+  heap.pop(); // remove -7
+  heap.pop(); // remove -5
+  heap.pop(); // remove 2
+
+  EXPECT_EQ(9, heap.top().data);
+}
+
+
+TEST(IndIntruSimplePQ, adjust) {
+  crimson::IndIntruSimplePQ<std::shared_ptr<Elem>,
+			Elem,
+			&Elem::heap_data,
+			ElemCompare> heap;
+
+  auto data1 = std::make_shared<Elem>(1);
+
+  heap.push(std::make_shared<Elem>(2));
+  heap.push(std::make_shared<Elem>(99));
+  heap.push(data1);
+  heap.push(std::make_shared<Elem>(-5));
+  heap.push(std::make_shared<Elem>(12));
+  heap.push(std::make_shared<Elem>(-12));
+  heap.push(std::make_shared<Elem>(-7));
+
+  // heap.display_sorted(std::cout);
+
+  EXPECT_EQ(-12, heap.top().data);
+
+  data1->data = 999;
+  heap.adjust(*data1);
+
+  EXPECT_EQ(-12, heap.top().data);
+
+  data1->data = -99;
+  heap.adjust(*data1);
+
+  EXPECT_EQ(-99, heap.top().data);
+
+  data1->data = 9;
+  heap.adjust(*data1);
+
+  EXPECT_EQ(-12, heap.top().data);
+
+  heap.pop(); // remove -12
+  heap.pop(); // remove -7
+  heap.pop(); // remove -5
+  heap.pop(); // remove 2
+
+  EXPECT_EQ(9, heap.top().data);
+}
+
+
+TEST_F(HeapFixture2, shared_data) {
+
+  crimson::IndIntruSimplePQ<std::shared_ptr<Elem>,Elem,&Elem::heap_data_alt,ElemCompareAlt> heap2;
+
+  heap2.push(data1);
+  heap2.push(data2);
+  heap2.push(data3);
+  heap2.push(data4);
+  heap2.push(data5);
+  heap2.push(data6);
+  heap2.push(data7);
+
+  data3->data = 32;
+  heap.adjust(*data3);
+  heap2.adjust(*data3);
+
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-7, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(32, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+
+  EXPECT_EQ(32, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(12, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(2, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(-12, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(99, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(-5, heap2.top().data);
+  heap2.pop();
+  EXPECT_EQ(-7, heap2.top().data);
+}
+
+
+TEST_F(HeapFixture2, iterator_basics) {
+  {
+    uint count = 0;
+    for(auto i = heap.begin(); i != heap.end(); ++i) {
+      ++count;
+    }
+
+    EXPECT_EQ(7, count) << "count should be 7";
+  }
+
+  auto i1 = heap.begin();
+
+  EXPECT_EQ(-12, i1->data) <<
+    "first member with * operator must be smallest";
+
+  EXPECT_EQ(-12, (*i1).data) <<
+    "first member with -> operator must be smallest";
+
+  Elem& e1 = *i1;
+  EXPECT_EQ(-12, e1.data) <<
+    "first member with -> operator must be smallest";
+
+  {
+    std::set<int> values;
+    values.insert(2);
+    values.insert(99);
+    values.insert(1);
+    values.insert(-5);
+    values.insert(12);
+    values.insert(-12);
+    values.insert(-7);
+
+    for(auto i = heap.begin(); i != heap.end(); ++i) {
+      auto v = *i;
+      EXPECT_NE(values.end(), values.find(v.data)) <<
+	"value in heap must be part of original set";
+      values.erase(v.data);
+    }
+    EXPECT_EQ(0, values.size()) << "all values must have been seen";
+  }
+}
+
+
+TEST_F(HeapFixture2, const_iterator_basics) {
+  const auto& cheap = heap;
+
+  {
+    uint count = 0;
+    for(auto i = cheap.cbegin(); i != cheap.cend(); ++i) {
+      ++count;
+    }
+
+    EXPECT_EQ(7, count) << "count should be 7";
+  }
+
+  auto i1 = heap.cbegin();
+
+  EXPECT_EQ(-12, i1->data) <<
+    "first member with * operator must be smallest";
+
+  EXPECT_EQ(-12, (*i1).data) <<
+    "first member with -> operator must be smallest";
+
+  const Elem& e1 = *i1;
+  EXPECT_EQ(-12, e1.data) <<
+    "first member with -> operator must be smallest";
+
+  {
+    std::set<int> values;
+    values.insert(2);
+    values.insert(99);
+    values.insert(1);
+    values.insert(-5);
+    values.insert(12);
+    values.insert(-12);
+    values.insert(-7);
+
+    for(auto i = heap.cbegin(); i != heap.cend(); ++i) {
+      auto v = *i;
+      EXPECT_NE(values.end(), values.find(v.data)) <<
+	"value in heap must be part of original set";
+      values.erase(v.data);
+    }
+    EXPECT_EQ(0, values.size()) << "all values must have been seen";
+  }
+}
+
+
+TEST_F(HeapFixture2, iterator_find_rfind) {
+  {
+    auto it1 = heap.find(data7);
+    EXPECT_NE(heap.end(), it1) << "find for included element should succeed";
+    EXPECT_EQ(-7, it1->data) <<
+      "find for included element should result in right value";
+
+    auto fake_data = std::make_shared<Elem>(-7);
+    auto it2 = heap.find(fake_data);
+    EXPECT_EQ(heap.end(), it2) << "find for not included element should fail";
+  }
+
+  {
+    auto it1 = heap.rfind(data7);
+    EXPECT_NE(heap.end(), it1) <<
+      "reverse find for included element should succeed";
+    EXPECT_EQ(-7, it1->data) <<
+      "reverse find for included element should result in right value";
+
+    auto fake_data = std::make_shared<Elem>(-7);
+    auto it2 = heap.rfind(fake_data);
+    EXPECT_EQ(heap.end(), it2) <<
+      "reverse find for not included element should fail";
+  }
+}
+
+
+TEST_F(HeapFixture2, iterator_remove) {
+  auto it1 = heap.find(data7);
+  EXPECT_NE(heap.end(), it1) << "find for included element should succeed";
+
+  heap.remove(it1);
+
+  auto it2 = heap.find(data7);
+  EXPECT_EQ(heap.end(), it2) << "find for removed element should fail";
+
+  for (auto it3 = heap.begin(); it3 != heap.end(); ++it3) {
+    EXPECT_NE(-7, it3->data) <<
+      "iterating through heap should not find removed value";
+  }
+
+  // move through heap without -7
+  EXPECT_EQ(-12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(-5, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(1, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(2, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(12, heap.top().data);
+  heap.pop();
+  EXPECT_EQ(99, heap.top().data);
+  heap.pop();
+}
+
+
+TEST_F(HeapFixture2, four_tops) {
+  Elem& top1 = heap.top();
+  EXPECT_EQ(-12, top1.data);
+
+  const Elem& top2 = heap.top();
+  EXPECT_EQ(-12, top2.data);
+
+  std::shared_ptr<Elem> top3 = heap.top_ind();
+  EXPECT_EQ(-12, top3->data);
+
+  const std::shared_ptr<Elem> top4 = heap.top_ind();
+  EXPECT_EQ(-12, top4->data);
+
+  const auto& c_heap = heap;
+
+  const Elem& top5 = c_heap.top();
+  EXPECT_EQ(-12, top5.data);
+
+  const std::shared_ptr<Elem> top6 = c_heap.top_ind();
+  EXPECT_EQ(-12, top6->data);
+}


### PR DESCRIPTION
Added a base-class named indirect_intrusive_base which is the parent of all indirect_intrusive heap implementation. The goal is to dynamically change heap data structure (for example, linear heap, or regular heap) in dmclock_server depending on the number of clients present at a time. 
    
Also, added USE_SIMPLE_HEAP flag to turn on simple linear heap (named ndirect_intrusive_linear_heap), that uses linear search, i.e., with O(num_of_clients) complexity. 
This simple heap can serve as a baseline for all future heap-implementation. 