### PR TITLE
Change limit heap to use adjust() instead of demote() after request pop.

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -775,7 +775,7 @@ namespace crimson {
 #endif
 
 	resv_heap.demote(top);
-	limit_heap.demote(top);
+	limit_heap.adjust(top);
 #if USE_PROP_HEAP
 	prop_heap.demote(top);
 #endif


### PR DESCRIPTION
The selected client is not the top of all heaps. So, some heaps need
promotion not demotion. The effect of this change can be seen at the below configuration clearly.

```
[global]                       
server_groups = 1              
client_groups = 2              
server_random_selection = false
server_soft_limit = true       
                               
[client.0]                     
client_count = 1               
client_wait = 0                
client_total_ops = 1000        
client_server_select_range = 4 
client_iops_goal = 60          
client_outstanding_ops = 100   
client_reservation = 20.0      
client_limit = 70.0            
client_weight = 1.0            
                               
[client.1]                     
client_count = 1               
client_wait = 0                
client_total_ops = 8000        
client_server_select_range = 4 
client_iops_goal = 800         
client_outstanding_ops = 100   
client_reservation = 20.0      
client_limit = 1000.0          
client_weight = 200.0          
                               
[server.0]                     
server_count = 4               
server_iops = 80               
server_threads = 1             

```