### PR TITLE
Fix to print result of the last second

### DIFF
--- a/sim/src/simulate.h
+++ b/sim/src/simulate.h
@@ -207,7 +207,7 @@ namespace crimson {
 	  while (it != end && *it < start_edge) { ++it; }
 
 	  for (auto time_edge = start_edge + measure_unit;
-	       time_edge < latest_finish;
+	       time_edge <= latest_finish + measure_unit;
 	       time_edge += measure_unit) {
 	    int count = 0;
 	    for (; it != end && *it < time_edge; ++count, ++it) { /* empty */ }


### PR DESCRIPTION
Fix to print result of the last second.

```
==== Client Data ====
     client:       0  total
        t_0:  148.50  148.50
        t_1:  148.50  148.50
        t_2:  148.50  148.50
        t_3:   54.50   54.50      <== This part was missed previously for all tests.
        t_4:    0.00    0.00
    res_ops:     334     334
   prop_ops:     666     666
```
