### PR TITLE
Fix idle client's prop_delta to set with others' previous tag when its queue is empty

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -710,13 +710,17 @@ namespace crimson {
 	    // don't use ourselves (or anything else that might be
 	    // listed as idle) since we're now in the map
 	    if (!c.second->idle) {
+	      double p;
 	      // use either lowest proportion tag or previous proportion tag
 	      if (c.second->has_request()) {
-		double p = c.second->next_request().tag.proportion +
+		p = c.second->next_request().tag.proportion +
 		  c.second->prop_delta;
-		if (p < lowest_prop_tag) {
-		  lowest_prop_tag = p;
-		}
+	      } else {
+	        p = c.second->get_req_tag().proportion + c.second->prop_delta;
+	      }
+
+	      if (p < lowest_prop_tag) {
+		lowest_prop_tag = p;
 	      }
 	    }
 	  }


### PR DESCRIPTION
I found a case that break the right proportional shares. I analysed this and found that sometimes prop_delta was set 0 for the newly inserted client record. In this dmclock code, the idle flag is not apply current state and take some times. Therefore, even if client had no request the client was not marked as idle. When a new client was inserted it would have 0 for prop_delta if other active clients didn't have any request. Consequently, new client will got proportional I/O service based on wrong prop_delta.
 To fix this, I use other clients' previous tag when the other client didn't have any request in its queue.

**Config file**

```
[global]
server_groups = 1
client_groups = 2
server_random_selection = false
server_soft_limit = false

[client.0]
client_count = 1
client_wait = 0
client_total_ops = 18000
client_server_select_range = 10
client_iops_goal = 2000
client_outstanding_ops = 32
client_reservation = 300.0
client_limit = 0.0
client_weight = 1.0

[client.1]
client_count = 1
client_wait = 6
client_total_ops = 10000
client_server_select_range = 10
client_iops_goal = 2000
client_outstanding_ops = 32
client_reservation = 250.0
client_limit = 0.0
client_weight = 1.0

[server.0]
server_count = 10
server_iops = 180
server_threads = 1
```

**Before:** Sometimes proportional share is broken. (But sometimes works well if there were some request
in the queue fortunately when new client was inserted)

```
==== Client Data ====
     client:       0       1  total
        t_0: 1770.50    0.00 1770.50
        t_1: 1777.50    0.00 1777.50
        t_2: 1777.50    0.00 1777.50
        t_3:  329.00 1449.00 1778.00      # Set same weight but not received same share !!!
        t_4:  354.50 1424.00 1778.50
        t_5:  423.50 1352.00 1775.50
        t_6: 1001.00  775.00 1776.00
        t_7: 1566.50    0.00 1566.50
        t_8:    0.00    0.00    0.00
    res_ops:    4581    1829    6410
   prop_ops:   13419    8171   21590
```

**After fix**

```
==== Client Data ====
     client:       0       1  total
        t_0: 1771.50    0.00 1771.50
        t_1: 1778.50    0.00 1778.50
        t_2: 1778.50    0.00 1778.50
        t_3:  888.50  888.00 1776.50
        t_4:  887.50  887.50 1775.00
        t_5:  889.00  889.50 1778.50
        t_6:  891.50  885.00 1776.50
        t_7:  115.00 1450.00 1565.00
        t_8:    0.00    0.00    0.00
    res_ops:    4162    2435    6597
   prop_ops:   13838    7565   21403
```
