### PR TITLE
fix delta&rho calculation for random server selection mode

### DIFF
--- a/src/dmclock_client.h
+++ b/src/dmclock_client.h
@@ -122,9 +122,12 @@ namespace crimson {
 	} else {
 	  Counter delta =
 	    delta_counter - it->second.delta_prev_req;
+#ifdef USE_SEPARATED_RHO_CAL
 	  Counter rho =
 	    rho_counter - it->second.rho_prev_req;
-
+#else
+	  Counter rho = delta;
+#endif
 	  it->second.req_update(delta_counter, rho_counter);
 
 	  return ReqParams(uint32_t(delta), uint32_t(rho));

--- a/src/dmclock_client.h
+++ b/src/dmclock_client.h
@@ -27,15 +27,11 @@ namespace crimson {
     struct ServerInfo {
       Counter   delta_prev_req;
       Counter   rho_prev_req;
-      uint32_t  my_delta;
-      uint32_t  my_rho;
 
       ServerInfo(Counter _delta_prev_req,
 		 Counter _rho_prev_req) :
 	delta_prev_req(_delta_prev_req),
-	rho_prev_req(_rho_prev_req),
-	my_delta(0),
-	my_rho(0)
+	rho_prev_req(_rho_prev_req)
       {
 	// empty
       }
@@ -43,13 +39,6 @@ namespace crimson {
       inline void req_update(Counter delta, Counter rho) {
 	delta_prev_req = delta;
 	rho_prev_req = rho;
-	my_delta = 0;
-	my_rho = 0;
-      }
-
-      inline void resp_update(PhaseType phase) {
-	++my_delta;
-	if (phase == PhaseType::reservation) ++my_rho;
       }
     };
 
@@ -114,19 +103,6 @@ namespace crimson {
        */
       void track_resp(const S& server_id, const PhaseType& phase) {
 	DataGuard g(data_mtx);
-
-	auto it = server_map.find(server_id);
-	if (server_map.end() == it) {
-	  // this code can only run if a request did not precede the
-	  // response or if the record was cleaned up b/w when
-	  // the request was made and now
-	  ServerInfo si(delta_counter, rho_counter);
-	  si.resp_update(phase);
-	  server_map.emplace(server_id, si);
-	} else {
-	  it->second.resp_update(phase);
-	}
-
 	++delta_counter;
 	if (PhaseType::reservation == phase) {
 	  ++rho_counter;
@@ -145,9 +121,9 @@ namespace crimson {
 	  return ReqParams(1, 1);
 	} else {
 	  Counter delta =
-	    1 + delta_counter - it->second.delta_prev_req - it->second.my_delta;
+	    delta_counter - it->second.delta_prev_req;
 	  Counter rho =
-	    1 + rho_counter - it->second.rho_prev_req - it->second.my_rho;
+	    rho_counter - it->second.rho_prev_req;
 
 	  it->second.req_update(delta_counter, rho_counter);
 

--- a/src/dmclock_recs.h
+++ b/src/dmclock_recs.h
@@ -35,7 +35,7 @@ namespace crimson {
 	delta(_delta),
 	rho(_rho)
       {
-	assert(0 != delta && 0 != rho && rho <= delta);
+	assert(rho <= delta);
       }
 
       ReqParams() :


### PR DESCRIPTION
I recently tested dmc_sim with ramdom_server_selection option enabling because that will be more similar with real Ceph environment. Unfortunately, the result is not stable. There were biases on select of server sometimes and that made wrong result. If the bias was occurred once it was not recovered and it kept until the end of simulation. I think the current code needs more resiliency. The main reason of lack of resiliency is the calculation of rho/delta value. In the current code rho/delta value are subtracted with my_rho/my_delta value. If large rho was calculated once and send to server, the server delays I/O requests for that client.  As a result, other servers will get small rho value because the server will send replies less frequently. But, the server got small rho doesn't care that because replies from that server ignored by subtraction by my_rho. (vise versa for case of small rho value). Conclusion is that if dmclock got biased rho/delta value once it will be kept forever. I attached a test configuration and result below. And I changed the rho/delta calculation code progressively and test again for better result.

**Test configuration**
```
[global]
server_groups = 1
client_groups = 2
server_random_selection = true
server_soft_limit = false

[client.0]
client_count = 1
client_wait = 0
client_total_ops = 10000
client_server_select_range = 4
client_iops_goal = 1000
client_outstanding_ops = 32
client_reservation = 250.0
client_limit = 5000.0
client_weight = 10.0

[client.1]
client_count = 1
client_wait = 0
client_total_ops = 35000
client_server_select_range = 4
client_iops_goal = 3000
client_outstanding_ops = 32
client_reservation = 0.0
client_limit = 10000.0
client_weight = 100.0

[server.0]
server_count = 4
server_iops = 400
server_threads = 1
```

**Test result of master branch**
```
==== Client Data ====
     client:       0       1  total
        t_0:  460.50 1082.00 1542.50
        t_1:  631.00  896.50 1527.50
        t_2:  882.50  600.00 1482.50
        t_3:  613.50  899.50 1513.00
        t_4:  596.00  923.00 1519.00
        t_5:  651.50  870.00 1521.50
        t_6:  666.00  827.50 1493.50
        t_7:  496.50 1021.50 1518.00
        t_8:    2.50 1485.00 1487.50
        t_9:    0.00 1489.00 1489.00
       t_10:    0.00 1487.00 1487.00
       t_11:    0.00 1479.00 1479.00
       t_12:    0.00 1504.50 1504.50
       t_13:    0.00 1459.00 1459.00
       t_14:    0.00 1476.50 1476.50
       t_15:    0.00    0.00    0.00
    res_ops:    3967       0    3967
   prop_ops:    6033   35000   41033
total time to track responses: 33906243 nanoseconds;
    count: 45000;
    average: 753.47 nanoseconds per request/response
total time to get request parameters: 142394147 nanoseconds;
    count: 45000;
    average: 3164.31 nanoseconds per request/response

client timing for QOS algorithm: 3917.79 nanoseconds per request/response

==== Server Data ====
     server:       0       1       2       3   total
    res_ops:    1463    1488      **52**     964    3967
   prop_ops:    9888    9799   **10994**   10352   41033
```

As you can see, client 0 got more share than its reservation parameter(250 iops). Because there was a bias for server selection with random server select option. One of servers has large rho value for client 0 in some time.(server 2 in upper case)  The server 2 will process client 1's requests more frequently than it was supposed to because client 0 doesn't use its resource due to large rho. After awhile client 1's queue in server 2 will be empty and client 0's requests will be served as proportional phase because there are no other client's requests. Even if other servers will process all reserved share, the server 2 process additional share for client 0 by proportional phase. As a result, Client 0 will get more shares than supposed to and right share will be broken.

The below is the graph of accumulative rho value of client 0 for each server.  You can see it diverse as time go.
![image](https://cloud.githubusercontent.com/assets/19993150/21255860/db914554-c3b1-11e6-8743-82958dfe6c1b.png)

To reinforce the resiliency, I fixed the rho/delta calculation at first commit (0cdb1b7642c8098dc079e62ec49d3093fb9b7a03). I removed my_rho/my_delta and the result is below.  
```
==== Client Data ====
     client:       0       1  total
        t_0:  497.50 1013.50 1511.00
        t_1:  456.00 1031.50 1487.50
        t_2:  469.50 1015.50 1485.00
        t_3:  457.00 1052.50 1509.50
        t_4:  466.00 1025.00 1491.00
        t_5:  465.00 1014.50 1479.50
        t_6:  519.00 1022.50 1541.50
        t_7:  487.00 1035.00 1522.00
        t_8:  402.50 1079.50 1482.00
        t_9:  427.00 1111.50 1538.50
       t_10:  353.50 1159.50 1513.00
       t_11:    0.00 1508.50 1508.50
       t_12:    0.00 1502.50 1502.50
       t_13:    0.00 1504.00 1504.00
       t_14:    0.00 1424.50 1424.50
       t_15:    0.00    0.00    0.00
    res_ops:    6510       0    6510
   prop_ops:    3490   35000   38490
total time to track responses: 35112316 nanoseconds;
    count: 45000;
    average: 780.27 nanoseconds per request/response
total time to get request parameters: 142748181 nanoseconds;
    count: 45000;
    average: 3172.18 nanoseconds per request/response

client timing for QOS algorithm: 3952.46 nanoseconds per request/response

==== Server Data ====
     server:       0       1       2       3   total
    res_ops:    1675    1487    1702    1646    6510
   prop_ops:    9625    9690    9517    9658   38490
```
![image](https://cloud.githubusercontent.com/assets/19993150/21255958/a0e6f7d6-c3b2-11e6-84db-09aef741f6cd.png)

Rho value diversity was disappeared and the result became better than the original code. But it was not enough. Client 0 got almost double IOPS than its parameter. I dug more and found another problem.  

Another problem was that rho value calculation ignored replies of proportional phase. With random server selction some request can be handled with proportional phase in some server because there could be bias in short time so that some other client's queue can be empty. In that case, some requests handled with proportional phase and the client get more share than it was supposed to. Therefore replies of proportional phase must not be ignored to compensate with reducing reservation service for the client that got proportional share. If we count replies of proportional phase for rho calculation it will get same number with delta. So, I set rho value with delta and tested(e2a642088cca685e4e374059f0d3e971a1c7aad5). The result is below.

```
==== Client Data ====
     client:       0       1  total
        t_0:  327.00 1216.50 1543.50
        t_1:  313.00 1204.00 1517.00
        t_2:  318.00 1190.50 1508.50
        t_3:  314.50 1190.50 1505.00
        t_4:  322.00 1183.00 1505.00
        t_5:  299.00 1172.00 1471.00
        t_6:  326.50 1148.00 1474.50
        t_7:  301.50 1187.00 1488.50
        t_8:  343.00 1181.50 1524.50
        t_9:  296.00 1222.00 1518.00
       t_10:  303.00 1174.50 1477.50
       t_11:  323.00 1211.00 1534.00
       t_12:  288.50 1248.00 1536.50
       t_13:  230.50 1299.50 1530.00
       t_14:  595.50  672.00 1267.50
       t_15:   99.00    0.00   99.00
       t_16:    0.00    0.00    0.00
    res_ops:    4345       0    4345
   prop_ops:    5655   35000   40655
```
I think it's quite acceptible number. I tested other configurations with random server selection mode too and the result was better with this code. I think rho variable need to be removed and replace it with delta variable although I just set rho with delta for convinience in this PR. I need your opinion before comlete the removing rho variable. 

And bspark's PR(#6) was effective for this configuration too. I think more reducing rho value make decrease proportional phase so that help to keep from handling request additionally that excess reservation parameter.  I will left comment about that at the PR page in sometime.