### PR TITLE
dmclock: Don't dump core when using EXPECT_DEATH_IF_SUPPORTED

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,8 @@
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES("sys/prctl.h" HAVE_SYS_PRCTL_H)
+CONFIGURE_FILE(dmtest-config.h.in dmtest-config.h)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(../src)
 include_directories(../support/src)
 include_directories(../sim/src)

--- a/test/dmtest-config.h.in
+++ b/test/dmtest-config.h.in
@@ -1,0 +1,2 @@
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+#cmakedefine HAVE_SYS_PRCTL_H 1


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19979

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>