### PR TITLE
set compiler flags via CMAKE_BUILD_TYPE to fix the error of compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 2.8.11)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
+
+if(DO_NOT_DELAY_TAG_CALC)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDO_NOT_DELAY_TAG_CALC")
+endif()
+
 if (NOT(TARGET gtest AND TARGET gtest_main))
   if(NOT(GTEST_FOUND))
     find_package(GTest REQUIRED)


### PR DESCRIPTION
when i try to compile dmclock at my computer, i got an error. try to set compiler flags via CMAKE_BUILD_TYPE to fix the error of compilation
`
In file included from /usr/include/c++/4.8.2/atomic:38:0,
                 from /root/dmclock/test/test_test_client.cc:7:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
In file included from /usr/include/c++/4.8.2/atomic:41:0,
                 from /root/dmclock/test/test_test_client.cc:7:
`

