### PR TITLE
Fix cmake files to handle GCC version 4 and other clean-up.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 2.8.11)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
+
 if (NOT(TARGET gtest AND TARGET gtest_main))
   if(NOT(GTEST_FOUND))
     find_package(GTest REQUIRED)
@@ -12,7 +15,6 @@ if (NOT(BOOST_FOUND))
   find_package(Boost REQUIRED)
 endif()
 
-# add_subdirectory(support/src)
 add_subdirectory(src)
 add_subdirectory(sim)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,23 +2,13 @@ include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(${Boost_INCLUDE_DIRS})
 include_directories(../support/src)
 
-set(local_flags "-std=c++11 -Wno-write-strings -Wall -pthread")
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
 
 if(DO_NOT_DELAY_TAG_CALC)
-  set(local_flags "${local_flags} -DDO_NOT_DELAY_TAG_CALC")
+  add_definitions(-DDO_NOT_DELAY_TAG_CALC)
 endif()
 
 set(dmc_srcs dmclock_util.cc ../support/src/run_every.cc)
-
-set_source_files_properties(${dmc_srcs}
-  PROPERTIES
-  COMPILE_FLAGS "${local_flags}"
-  )
-
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(warnings_off " -Wno-unused-variable -Wno-unused-function")
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  set(warnings_off " -Wno-unused-but-set-variable -Wno-unused-function")
-endif()
 
 add_library(dmclock STATIC ${dmc_srcs})


### PR DESCRIPTION
Set compiler flags at higher level CMakeLists.txt file, so they apply
to sim and test, and so earlier versions of GCC know to use c++11
standard. Clean up cmake files in general.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>