### PR TITLE
enforce move semantics of request types

### DIFF
--- a/sim/src/sim_client.h
+++ b/sim/src/sim_client.h
@@ -89,7 +89,7 @@ namespace crimson {
 
       using SubmitFunc =
 	std::function<void(const ServerId&,
-			   const TestRequest&,
+			   TestRequest&&,
 			   const ClientId&,
 			   const ReqPm&)>;
 
@@ -240,8 +240,9 @@ namespace crimson {
 	      count_stats(internal_stats.mtx,
 			  internal_stats.get_req_params_count);
 
-	      TestRequest req(server, o, 12);
-	      submit_f(server, req, id, rp);
+	      submit_f(server,
+		       TestRequest{server, static_cast<uint32_t>(o), 12},
+		       id, rp);
 	      ++outstanding_ops;
 	      l.lock(); // lock for return to top of loop
 

--- a/sim/src/sim_server.h
+++ b/sim/src/sim_server.h
@@ -147,14 +147,15 @@ namespace crimson {
 	delete priority_queue;
       }
 
-      void post(const TestRequest& request,
+      void post(TestRequest&& request,
 		const ClientId& client_id,
 		const ReqPm& req_params)
       {
 	time_stats(internal_stats.mtx,
 		   internal_stats.add_request_time,
 		   [&](){
-		     priority_queue->add_request(request, client_id, req_params);
+		     priority_queue->add_request(std::move(request),
+						 client_id, req_params);
 		   });
 	count_stats(internal_stats.mtx,
 		    internal_stats.add_request_count);
@@ -202,10 +203,9 @@ namespace crimson {
 	    // notify server of completion
 	    std::this_thread::sleep_for(op_time);
 
-	    TestResponse resp(req->epoch);
 	    // TODO: rather than assuming this constructor exists, perhaps
 	    // pass in a function that does this mapping?
-	    client_resp_f(client, resp, id, additional);
+	    client_resp_f(client, TestResponse{req->epoch}, id, additional);
 
 	    time_stats(internal_stats.mtx,
 		       internal_stats.request_complete_time,

--- a/sim/src/ssched/ssched_server.h
+++ b/sim/src/ssched/ssched_server.h
@@ -100,10 +100,11 @@ namespace crimson {
 	finishing = true;
       }
 
-      void add_request(const R& request,
+      void add_request(R&& request,
 		       const C& client_id,
 		       const ReqParams& req_params) {
-	add_request(RequestRef(new R(request)), client_id, req_params);
+	add_request(RequestRef(new R(std::move(request))),
+		    client_id, req_params);
       }
 
       void add_request(RequestRef&& request,

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -136,11 +136,11 @@ int main(int argc, char* argv[]) {
     // lambda to post a request to the identified server; called by client
     test::SubmitFunc server_post_f =
         [&simulation](const ServerId& server,
-                      const sim::TestRequest& request,
+                      sim::TestRequest&& request,
                       const ClientId& client_id,
                       const test::dmc::ReqParams& req_params) {
         test::DmcServer& s = simulation->get_server(server);
-        s.post(request, client_id, req_params);
+        s.post(std::move(request), client_id, req_params);
     };
 
     std::vector<std::vector<sim::CliInst>> cli_inst;

--- a/sim/src/test_ssched_main.cc
+++ b/sim/src/test_ssched_main.cc
@@ -67,11 +67,11 @@ int main(int argc, char* argv[]) {
   // lambda to post a request to the identified server; called by client
   test::SubmitFunc server_post_f =
     [&simulation](const ServerId& server_id,
-		  const sim::TestRequest& request,
+		  sim::TestRequest&& request,
 		  const ClientId& client_id,
 		  const ssched::ReqParams& req_params) {
     auto& server = simulation->get_server(server_id);
-    server.post(request, client_id, req_params);
+    server.post(std::move(request), client_id, req_params);
   };
 
   static std::vector<sim::CliInst> no_wait =

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -371,12 +371,12 @@ namespace crimson {
 
 	// NB: because a deque is the underlying structure, this
 	// operation might be expensive
-	bool remove_by_req_filter_fw(std::function<bool(const R&)> filter_accum) {
+	bool remove_by_req_filter_fw(std::function<bool(R&&)> filter_accum) {
 	  bool any_removed = false;
 	  for (auto i = requests.begin();
 	       i != requests.end();
 	       /* no inc */) {
-	    if (filter_accum(*i->request)) {
+	    if (filter_accum(std::move(*i->request))) {
 	      any_removed = true;
 	      i = requests.erase(i);
 	    } else {
@@ -388,12 +388,12 @@ namespace crimson {
 
 	// NB: because a deque is the underlying structure, this
 	// operation might be expensive
-	bool remove_by_req_filter_bw(std::function<bool(const R&)> filter_accum) {
+	bool remove_by_req_filter_bw(std::function<bool(R&&)> filter_accum) {
 	  bool any_removed = false;
 	  for (auto i = requests.rbegin();
 	       i != requests.rend();
 	       /* no inc */) {
-	    if (filter_accum(*i->request)) {
+	    if (filter_accum(std::move(*i->request))) {
 	      any_removed = true;
 	      i = decltype(i){ requests.erase(std::next(i).base()) };
 	    } else {
@@ -404,7 +404,7 @@ namespace crimson {
 	}
 
 	inline bool
-	remove_by_req_filter(std::function<bool(const R&)> filter_accum,
+	remove_by_req_filter(std::function<bool(R&&)> filter_accum,
 			     bool visit_backwards) {
 	  if (visit_backwards) {
 	    return remove_by_req_filter_bw(filter_accum);
@@ -478,7 +478,7 @@ namespace crimson {
       }
 
 
-      bool remove_by_req_filter(std::function<bool(const R&)> filter_accum,
+      bool remove_by_req_filter(std::function<bool(R&&)> filter_accum,
 				bool visit_backwards = false) {
 	bool any_removed = false;
 	DataGuard g(data_mtx);
@@ -500,14 +500,14 @@ namespace crimson {
 
 
       // use as a default value when no accumulator is provide
-      static void request_sink(const R& req) {
+      static void request_sink(R&& req) {
 	// do nothing
       }
 
 
       void remove_by_client(const C& client,
 			    bool reverse = false,
-			    std::function<void (const R&)> accum = request_sink) {
+			    std::function<void (R&&)> accum = request_sink) {
 	DataGuard g(data_mtx);
 
 	auto i = client_map.find(client);
@@ -518,13 +518,13 @@ namespace crimson {
 	  for (auto j = i->second->requests.rbegin();
 	       j != i->second->requests.rend();
 	       ++j) {
-	    accum(*j->request);
+	    accum(std::move(*j->request));
 	  }
 	} else {
 	  for (auto j = i->second->requests.begin();
 	       j != i->second->requests.end();
 	       ++j) {
-	    accum(*j->request);
+	    accum(std::move(*j->request));
 	  }
 	}
 
@@ -1162,11 +1162,11 @@ namespace crimson {
       }
 
 
-      inline void add_request(const R& request,
+      inline void add_request(R&& request,
 			      const C& client_id,
 			      const ReqParams& req_params,
 			      double addl_cost = 0.0) {
-	add_request(typename super::RequestRef(new R(request)),
+	add_request(typename super::RequestRef(new R(std::move(request))),
 		    client_id,
 		    req_params,
 		    get_time(),
@@ -1174,11 +1174,11 @@ namespace crimson {
       }
 
 
-      inline void add_request(const R& request,
+      inline void add_request(R&& request,
 			      const C& client_id,
 			      double addl_cost = 0.0) {
 	static const ReqParams null_req_params;
-	add_request(typename super::RequestRef(new R(request)),
+	add_request(typename super::RequestRef(new R(std::move(request))),
 		    client_id,
 		    null_req_params,
 		    get_time(),
@@ -1187,12 +1187,12 @@ namespace crimson {
 
 
 
-      inline void add_request_time(const R& request,
+      inline void add_request_time(R&& request,
 				   const C& client_id,
 				   const ReqParams& req_params,
 				   const Time time,
 				   double addl_cost = 0.0) {
-	add_request(typename super::RequestRef(new R(request)),
+	add_request(typename super::RequestRef(new R(std::move(request))),
 		    client_id,
 		    req_params,
 		    time,
@@ -1402,11 +1402,11 @@ namespace crimson {
 
     public:
 
-      inline void add_request(const R& request,
+      inline void add_request(R&& request,
 			      const C& client_id,
 			      const ReqParams& req_params,
 			      double addl_cost = 0.0) {
-	add_request(typename super::RequestRef(new R(request)),
+	add_request(typename super::RequestRef(new R(std::move(request))),
 		    client_id,
 		    req_params,
 		    get_time(),

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -64,20 +64,19 @@ namespace crimson {
       };
 
       QueueRef pq(new Queue(client_info_f, false));
-      Request req;
       ReqParams req_params(1,1);
 
       // Disable coredumps
       PrCtl unset_dumpable;
 
-      EXPECT_DEATH_IF_SUPPORTED(pq->add_request(req, client1, req_params),
+      EXPECT_DEATH_IF_SUPPORTED(pq->add_request(Request{}, client1, req_params),
 				"Assertion.*reservation.*max_tag.*"
 				"proportion.*max_tag") <<
 	"we should fail if a client tries to generate a reservation tag "
 	"where reservation and proportion are both 0";
 
 
-      EXPECT_DEATH_IF_SUPPORTED(pq->add_request(req, client2, req_params),
+      EXPECT_DEATH_IF_SUPPORTED(pq->add_request(Request{}, client2, req_params),
 				"Assertion.*reservation.*max_tag.*"
 				"proportion.*max_tag") <<
 	"we should fail if a client tries to generate a reservation tag "
@@ -554,14 +553,13 @@ namespace crimson {
 
       pq = QueueRef(new Queue(client_info_f, false));
 
-      Request req;
       ReqParams req_params(1,1);
 
       auto now = dmc::get_time();
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request(req, client1, req_params);
-	pq->add_request(req, client2, req_params);
+	pq->add_request(Request{}, client1, req_params);
+	pq->add_request(Request{}, client2, req_params);
 	now += 0.0001;
       }
 
@@ -608,15 +606,14 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, false));
 
-      Request req;
       ReqParams req_params(1,1);
 
       // make sure all times are well before now
       auto old_time = dmc::get_time() - 100.0;
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request_time(req, client1, req_params, old_time);
-	pq->add_request_time(req, client2, req_params, old_time);
+	pq->add_request_time(Request{}, client1, req_params, old_time);
+	pq->add_request_time(Request{}, client2, req_params, old_time);
 	old_time += 0.001;
       }
 
@@ -667,7 +664,6 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, false));
 
-      Request req;
       ReqParams req_params(1,1);
 
       // make sure all times are well before now
@@ -675,8 +671,8 @@ namespace crimson {
 
       // add six requests; for same client reservations spaced one apart
       for (int i = 0; i < 3; ++i) {
-	pq->add_request_time(req, client1, req_params, start_time);
-	pq->add_request_time(req, client2, req_params, start_time);
+	pq->add_request_time(Request{}, client1, req_params, start_time);
+	pq->add_request_time(Request{}, client2, req_params, start_time);
       }
 
       Queue::PullReq pr = pq->pull_request(start_time + 0.5);
@@ -750,13 +746,12 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, false));
 
-      Request req;
       ReqParams req_params(1,1);
 
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(req, client1, req_params, now + 100);
+      pq->add_request_time(Request{}, client1, req_params, now + 100);
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::future, pr.type);
@@ -782,13 +777,12 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, true));
 
-      Request req;
       ReqParams req_params(1,1);
 
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(req, client1, req_params, now + 100);
+      pq->add_request_time(Request{}, client1, req_params, now + 100);
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);
@@ -814,13 +808,12 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, true));
 
-      Request req;
       ReqParams req_params(1,1);
 
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(req, client1, req_params, now + 100);
+      pq->add_request_time(Request{}, client1, req_params, now + 100);
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);


### PR DESCRIPTION
this requires the request type support move semantics, but the upside is
that the request type will not be copied under any circumstances.

Signed-off-by: Kefu Chai <kchai@redhat.com>