### PR TITLE
dmclock_server.h: remove redundant break statement

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1254,11 +1254,9 @@ namespace crimson {
 	switch(next.type) {
 	case super::NextReqType::none:
 	  return result;
-	  break;
 	case super::NextReqType::future:
 	  result.data = next.when_ready;
 	  return result;
-	  break;
 	case super::NextReqType::returning:
 	  // to avoid nesting, break out and let code below handle this case
 	  break;


### PR DESCRIPTION
Signed-off-by: dingdangzhang <boqian.zy@alibaba-inc.com>
since there is such a return why break statement?so delete it.