### PR TITLE
Fix issues regarding building and DO_NOT_DELAY_TAG_CALC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 set(CMAKE_CXX_FLAGS
   "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
 
+if(DO_NOT_DELAY_TAG_CALC)
+  add_definitions(-DDO_NOT_DELAY_TAG_CALC)
+endif()
+
 if (NOT(TARGET gtest AND TARGET gtest_main))
   if (NOT GTEST_FOUND)
     find_package(GTest QUIET)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,6 @@ include_directories(../support/src)
 set(CMAKE_CXX_FLAGS
   "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
 
-if(DO_NOT_DELAY_TAG_CALC)
-  add_definitions(-DDO_NOT_DELAY_TAG_CALC)
-endif()
-
 set(dmc_srcs dmclock_util.cc ../support/src/run_every.cc)
 
 add_library(dmclock STATIC ${dmc_srcs})

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -880,7 +880,9 @@ namespace crimson {
 	ClientRec& top = heap.top();
 
 	RequestRef request = std::move(top.next_request().request);
+#ifndef DO_NOT_DELAY_TAG_CALC
 	RequestTag tag = top.next_request().tag;
+#endif
 
 	// pop request and adjust heaps
 	top.pop_request();


### PR DESCRIPTION
Moved the check for cmake's DO_NOT_DELAY_TAG_CALC to the top level, so it will affect how tests are built. Also addressed an unused variable when DO_NOT_DELAY_TAG_CALC is not defined.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>