### PR TITLE
 Add anticipation duration that keeps from resetting tag values to the current time

### DIFF
--- a/sim/src/config.cc
+++ b/sim/src/config.cc
@@ -130,6 +130,8 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
     g_conf.server_random_selection = stobool(val);
   if (!cf.read("global", "server_soft_limit", val))
     g_conf.server_soft_limit = stobool(val);
+  if (!cf.read("global", "anticipation_timeout", val))
+    g_conf.anticipation_timeout = stod(val);
 
   for (uint i = 0; i < g_conf.server_groups; i++) {
     srv_group_t st;

--- a/sim/src/config.h
+++ b/sim/src/config.h
@@ -100,6 +100,7 @@ namespace crimson {
       uint client_groups;
       bool server_random_selection;
       bool server_soft_limit;
+      double anticipation_timeout;
 
       std::vector<cli_group_t> cli_group;
       std::vector<srv_group_t> srv_group;
@@ -107,11 +108,13 @@ namespace crimson {
       sim_config_t(uint _server_groups = 1,
 		   uint _client_groups = 1,
 		   bool _server_random_selection = false,
-		   bool _server_soft_limit = true) :
+		   bool _server_soft_limit = true,
+		   double _anticipation_timeout = 0.0) :
 	server_groups(_server_groups),
 	client_groups(_client_groups),
 	server_random_selection(_server_random_selection),
-	server_soft_limit(_server_soft_limit)
+	server_soft_limit(_server_soft_limit),
+	anticipation_timeout(_anticipation_timeout)
       {
 	srv_group.reserve(server_groups);
 	cli_group.reserve(client_groups);
@@ -123,7 +126,9 @@ namespace crimson {
 	  "server_groups = " << sim_config.server_groups << "\n" <<
 	  "client_groups = " << sim_config.client_groups << "\n" <<
 	  "server_random_selection = " << sim_config.server_random_selection << "\n" <<
-	  "server_soft_limit = " << sim_config.server_soft_limit;
+	  "server_soft_limit = " << sim_config.server_soft_limit << "\n" <<
+	  std::fixed << std::setprecision(3) << 
+	  "anticipation_timeout = " << sim_config.anticipation_timeout;
 	return out;
       }
     }; // class sim_config_t

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -74,6 +74,7 @@ int main(int argc, char* argv[]) {
     const uint client_groups = g_conf.client_groups;
     const bool server_random_selection = g_conf.server_random_selection;
     const bool server_soft_limit = g_conf.server_soft_limit;
+    const double anticipation_timeout = g_conf.anticipation_timeout;
     uint server_total_count = 0;
     uint client_total_count = 0;
 
@@ -176,7 +177,11 @@ int main(int argc, char* argv[]) {
     test::CreateQueueF create_queue_f =
         [&](test::DmcQueue::CanHandleRequestFunc can_f,
             test::DmcQueue::HandleRequestFunc handle_f) -> test::DmcQueue* {
-        return new test::DmcQueue(client_info_f, can_f, handle_f, server_soft_limit);
+        return new test::DmcQueue(client_info_f,
+                                  can_f,
+                                  handle_f,
+                                  server_soft_limit,
+                                  anticipation_timeout);
     };
 
  

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -109,36 +109,38 @@ namespace crimson {
       double proportion;
       double limit;
       bool   ready; // true when within limit
-#ifndef DO_NOT_DELAY_TAG_CALC
       Time   arrival;
-#endif
 
       RequestTag(const RequestTag& prev_tag,
 		 const ClientInfo& client,
 		 const uint32_t delta,
 		 const uint32_t rho,
 		 const Time time,
-		 const double cost = 0.0) :
-	reservation(cost + tag_calc(time,
-				    prev_tag.reservation,
-				    client.reservation_inv,
-				    rho,
-				    true)),
-	proportion(tag_calc(time,
-			    prev_tag.proportion,
-			    client.weight_inv,
-			    delta,
-			    true)),
-	limit(tag_calc(time,
-		       prev_tag.limit,
-		       client.limit_inv,
-		       delta,
-		       false)),
-	ready(false)
-#ifndef DO_NOT_DELAY_TAG_CALC
-	, arrival(time)
-#endif
+		 const double cost = 0.0,
+		 const double anticipation_timeout = 0.0) :
+	ready(false),
+	arrival(time)
       {
+	Time max_time = time;
+	if (time - anticipation_timeout < prev_tag.arrival)
+	  max_time -= anticipation_timeout;
+	
+	reservation = cost + tag_calc(max_time,
+				      prev_tag.reservation,
+				      client.reservation_inv,
+				      rho,
+				      true);
+	proportion = tag_calc(max_time,
+			      prev_tag.proportion,
+			      client.weight_inv,
+			      delta,
+			      true);
+	limit = tag_calc(max_time,
+			 prev_tag.limit,
+			 client.limit_inv,
+			 delta,
+			 false);
+
 	assert(reservation < max_tag || proportion < max_tag);
       }
 
@@ -146,18 +148,18 @@ namespace crimson {
 		 const ClientInfo& client,
 		 const ReqParams req_params,
 		 const Time time,
-		 const double cost = 0.0) :
-	RequestTag(prev_tag, client, req_params.delta, req_params.rho, time, cost)
+		 const double cost = 0.0,
+		 const double anticipation_timeout = 0.0) :
+	RequestTag(prev_tag, client, req_params.delta, req_params.rho, time,
+		   cost, anticipation_timeout)
       { /* empty */ }
 
       RequestTag(double _res, double _prop, double _lim, const Time _arrival) :
 	reservation(_res),
 	proportion(_prop),
 	limit(_lim),
-	ready(false)
-#ifndef DO_NOT_DELAY_TAG_CALC
-	, arrival(_arrival)
-#endif
+	ready(false),
+	arrival(_arrival)
       {
 	assert(reservation < max_tag || proportion < max_tag);
       }
@@ -166,10 +168,8 @@ namespace crimson {
 	reservation(other.reservation),
 	proportion(other.proportion),
 	limit(other.limit),
-	ready(other.ready)
-#ifndef DO_NOT_DELAY_TAG_CALC
-	, arrival(other.arrival)
-#endif
+	ready(other.ready),
+	arrival(other.arrival)
       {
 	// empty
       }
@@ -340,6 +340,7 @@ namespace crimson {
 	  assign_unpinned_tag(prev_tag.reservation, _prev.reservation);
 	  assign_unpinned_tag(prev_tag.limit, _prev.limit);
 	  assign_unpinned_tag(prev_tag.proportion, _prev.proportion);
+	  prev_tag.arrival = _prev.arrival;
 	  last_tick = _tick;
 	}
 
@@ -714,6 +715,7 @@ namespace crimson {
       // limit, this will allow the request next in terms of
       // proportion to still get issued
       bool             allow_limit_break;
+      double           anticipation_timeout;
 
       std::atomic_bool finishing;
 
@@ -742,9 +744,11 @@ namespace crimson {
 			std::chrono::duration<Rep,Per> _idle_age,
 			std::chrono::duration<Rep,Per> _erase_age,
 			std::chrono::duration<Rep,Per> _check_time,
-			bool _allow_limit_break) :
+			bool _allow_limit_break,
+			double _anticipation_timeout) :
 	client_info_f(_client_info_f),
 	allow_limit_break(_allow_limit_break),
+	anticipation_timeout(_anticipation_timeout),
 	finishing(false),
 	idle_age(std::chrono::duration_cast<Duration>(_idle_age)),
 	erase_age(std::chrono::duration_cast<Duration>(_erase_age)),
@@ -862,13 +866,20 @@ namespace crimson {
 			   get_cli_info(client),
 			   req_params,
 			   time,
-			   cost);
+			   cost,
+                           anticipation_timeout);
 
 	  // copy tag to previous tag for client
 	  client.update_req_tag(tag, tick);
 	}
 #else
-	RequestTag tag(client.get_req_tag(), get_cli_info(client), req_params, time, cost);
+	RequestTag tag(client.get_req_tag(),
+		       get_cli_info(client),
+		       req_params,
+		       time,
+		       cost,
+		       anticipation_timeout);
+
 	// copy tag to previous tag for client
 	client.update_req_tag(tag, tick);
 #endif
@@ -920,7 +931,8 @@ namespace crimson {
 	  ClientReq& next_first = top.next_request();
 	  next_first.tag = RequestTag(tag, get_cli_info(top),
 				      top.cur_delta, top.cur_rho,
-				      next_first.tag.arrival);
+				      next_first.tag.arrival,
+                                      0.0, anticipation_timeout);
 
   	  // copy tag to previous tag for client
 	  top.update_req_tag(next_first.tag, tick);
@@ -1169,10 +1181,11 @@ namespace crimson {
 			std::chrono::duration<Rep,Per> _idle_age,
 			std::chrono::duration<Rep,Per> _erase_age,
 			std::chrono::duration<Rep,Per> _check_time,
-			bool _allow_limit_break = false) :
+			bool _allow_limit_break = false,
+			double _anticipation_timeout = 0.0) :
 	super(_client_info_f,
 	      _idle_age, _erase_age, _check_time,
-	      _allow_limit_break)
+	      _allow_limit_break, _anticipation_timeout)
       {
 	// empty
       }
@@ -1393,10 +1406,11 @@ namespace crimson {
 			std::chrono::duration<Rep,Per> _idle_age,
 			std::chrono::duration<Rep,Per> _erase_age,
 			std::chrono::duration<Rep,Per> _check_time,
-			bool _allow_limit_break = false) :
+			bool _allow_limit_break = false,
+			double anticipation_timeout = 0.0) :
 	super(_client_info_f,
 	      _idle_age, _erase_age, _check_time,
-	      _allow_limit_break)
+	      _allow_limit_break, anticipation_timeout)
       {
 	can_handle_f = _can_handle_f;
 	handle_f = _handle_f;
@@ -1408,14 +1422,16 @@ namespace crimson {
       PushPriorityQueue(typename super::ClientInfoFunc _client_info_f,
 			CanHandleRequestFunc _can_handle_f,
 			HandleRequestFunc _handle_f,
-			bool _allow_limit_break = false) :
+			bool _allow_limit_break = false,
+			double _anticipation_timeout = 0.0) :
 	PushPriorityQueue(_client_info_f,
 			  _can_handle_f,
 			  _handle_f,
 			  std::chrono::minutes(10),
 			  std::chrono::minutes(15),
 			  std::chrono::minutes(6),
-			  _allow_limit_break)
+			  _allow_limit_break,
+			  _anticipation_timeout)
       {
 	// empty
       }


### PR DESCRIPTION
The deceptive idleness problem is addressed in the below paper.
https://www.usenix.org/system/files/conference/atc13/atc13-shen.pdf
The dmClock has the same problem because it is also one of fair queueing type schedulers.
I applied anticipation_timeout variable for the tag calculation to solve the deceptive idleness problem.
A request that is arrived in short time after previous request's arrival will not be set current time as its tag, even if the calculated tag value is greater than the current time.
This change helps a client to take their unused resource that could be forfeited by other aggressive clients.
Specifically, in random mode, the resource forfeiture is worse because the request arrival time is irregular, tag value is frequently set to the current time during tag calculation.

I attach an example below.
Client 1's reservation is 800 IOPS but it was not kept before. After applying this patch, there is an improvement.


**- Config file**
Anticipation is configurable with anticipation_timeout option. There is no anticipation effect when it's set by 0.
```
[global]
server_groups = 1
client_groups = 3
server_random_selection = true
server_soft_limit = false
anticipation_timeout = 1.0

[client.0]
client_count = 1
client_wait = 0
client_total_ops = 20000
client_server_select_range = 8
client_iops_goal = 1000
client_outstanding_ops = 64
client_reservation = 250.0
client_limit = 5000.0
client_weight = 1.0

[client.1]
client_count = 1
client_wait = 0
client_total_ops = 20000
client_server_select_range = 8
client_iops_goal = 1000
client_outstanding_ops = 16
client_reservation = 800.0
client_limit = 5000.0
client_weight = 1.0

[client.2]
client_count = 1
client_wait = 0
client_total_ops = 20000
client_server_select_range = 8
client_iops_goal = 3000
client_outstanding_ops = 64
client_reservation = 100.0
client_limit = 10000.0
client_weight = 1.0

[server.0]
server_count = 8
server_iops = 200
server_threads = 1
```

**- The result without anticipation**
```
==== Client Data ====                       
     client:       0       1       2  total 
        t_0:  515.00  628.00  411.50 1554.50
        t_1:  545.00  522.00  446.00 1513.00
        t_2:  481.50  591.50  467.00 1540.00
        t_3:  507.50  564.50  480.50 1552.50
        t_4:  478.00  571.50  517.00 1566.50
        t_5:  433.00  452.00  646.00 1531.00
        t_6:  637.50  502.00  392.00 1531.50
        t_7:  588.50  549.00  390.00 1527.50
        t_8:  403.00  636.50  479.50 1519.00
        t_9:  396.50  722.50  386.00 1505.00
       t_10:  536.50  633.00  379.00 1548.50
       t_11:  600.50  495.50  422.50 1518.50
       t_12:  662.50  458.50  402.50 1523.50
       t_13:  630.00  503.00  402.50 1535.50
       t_14:  667.50  418.00  443.50 1529.00
       t_15:  714.00  396.00  403.50 1513.50
       t_16:  588.00  309.50  619.00 1516.50
       t_17:  355.50  402.50  771.00 1529.00
       t_18:  260.00  419.00  830.00 1509.00
       t_19:    0.00  225.50  711.00  936.50
       t_20:    0.00    0.00    0.00    0.00
    res_ops:    9119   19538    4057   32714
   prop_ops:   10881     462   15943   27286
```

**- The result after this change**
```
==== Client Data ====
     client:       0       1       2  total
        t_0:  445.50  744.50  361.00 1551.00
        t_1:  431.50  720.50  369.50 1521.50
        t_2:  459.50  735.50  330.50 1525.50
        t_3:  483.00  709.00  309.00 1501.00
        t_4:  472.00  693.00  364.50 1529.50
        t_5:  516.50  738.50  301.50 1556.50
        t_6:  396.50  719.50  423.50 1539.50
        t_7:  337.00  836.00  358.00 1531.00
        t_8:  412.50  825.00  284.50 1522.00
        t_9:  448.50  786.00  284.00 1518.50
       t_10:  458.50  843.00  221.00 1522.50
       t_11:  478.00  741.50  322.50 1542.00
       t_12:  272.50  831.50  462.50 1566.50
       t_13:  557.00   76.50  880.00 1513.50
       t_14:  637.50    0.00  902.50 1540.00
       t_15:  812.50    0.00  706.00 1518.50
       t_16:  909.50    0.00  539.50 1449.00
       t_17:  873.00    0.00  662.00 1535.00
       t_18:  581.50    0.00  948.00 1529.50
       t_19:   17.50    0.00  970.00  987.50
       t_20:    0.00    0.00    0.00    0.00
    res_ops:    9452   20000    4086   33538
   prop_ops:   10548       0   15914   26462
```