### PR TITLE
cleanup: fix includes for gcc 7.1.1

### DIFF
--- a/sim/src/sim_recs.h
+++ b/sim/src/sim_recs.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <mutex>
 #include <iostream>
+#include <functional>
 
 
 using ClientId = uint;

--- a/sim/src/ssched/ssched_server.h
+++ b/sim/src/ssched/ssched_server.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <mutex>
 #include <deque>
+#include <functional>
 
 #include "boost/variant.hpp"
 

--- a/support/src/run_every.h
+++ b/support/src/run_every.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <thread>
+#include <functional>
 
 
 namespace crimson {


### PR DESCRIPTION
With upgrade to gcc 7.1.1, need to include <functional> in additional header files.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>