### PR TITLE
Fix uninitialized scalar data

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -296,11 +296,11 @@ namespace crimson {
 	// an idle client becoming unidle
 	double                prop_delta = 0.0;
 
-	c::IndIntruHeapData   reserv_heap_data;
-	c::IndIntruHeapData   lim_heap_data;
-	c::IndIntruHeapData   ready_heap_data;
+	c::IndIntruHeapData   reserv_heap_data = 0;
+	c::IndIntruHeapData   lim_heap_data = 0;
+	c::IndIntruHeapData   ready_heap_data = 0;
 #if USE_PROP_HEAP
-	c::IndIntruHeapData   prop_heap_data;
+	c::IndIntruHeapData   prop_heap_data = 0;
 #endif
 
       public:


### PR DESCRIPTION
The coverity scan published in ceph-devel on 2017-09-21 revealed some uninitialized data in a constructor. This fixes that.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>