### PR TITLE
build: Mark dependency includes as SYSTEM in dmclock

### DIFF
--- a/sim/src/CMakeLists.txt
+++ b/sim/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(ssched) # ssched code
 include_directories(../../src) # dmclock code
 include_directories(../../support/src)
-include_directories(${BOOST_INCLUDE_DIR})
+include_directories(SYSTEM ${BOOST_INCLUDE_DIR})
 
 set(local_flags "-Wall -pthread ${CMAKE_CXX_SIM_FLAGS}")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-include_directories(${GTEST_INCLUDE_DIRS})
-include_directories(${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories(../support/src)
 
 set(CMAKE_CXX_FLAGS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,7 @@ set_source_files_properties(${core_srcs} ${test_srcs}
   )
 
 add_executable(dmclock-tests ${test_srcs} ${support_srcs})
-target_include_directories(dmclock-tests PRIVATE "${GTEST_INCLUDE_DIRS}")
+target_include_directories(dmclock-tests PRIVATE SYSTEM "${GTEST_INCLUDE_DIRS}")
 
 if (TARGET gtest AND TARGET gtest_main)
   add_dependencies(dmclock-tests gtest gtest_main)


### PR DESCRIPTION
It is not really our business to debug boost, gtest or our other
dependencies. Mark them as system includes.