### PR TITLE
Reduce the size of enum class PhaseType

### DIFF
--- a/src/dmclock_recs.h
+++ b/src/dmclock_recs.h
@@ -17,7 +17,7 @@ namespace crimson {
   namespace dmclock {
     using Counter = uint64_t;
 
-    enum class PhaseType { reservation, priority };
+    enum class PhaseType : uint8_t { reservation, priority };
 
     inline std::ostream& operator<<(std::ostream& out, const PhaseType& phase) {
       out << (PhaseType::reservation == phase ? "reservation" : "priority");


### PR DESCRIPTION
I think it's too large using default enum class type for the PhaseType.
Rather than using 4 bytes, It would be better to use only 1 byte.

Furthermore, the current ceph's denc.h implementation doesn't support 4 or 2 bytes underlying typed enum. (I don't know it's intended or not).

Anyway, I think decreasing the size would be good.