### PR TITLE
Allow the dmclock library to handle the "cost" of an operation/request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.dSYM
 *.o
 build*
+cscope.*

--- a/sim/dmc_sim_example.conf
+++ b/sim/dmc_sim_example.conf
@@ -1,6 +1,6 @@
 [global]
 server_groups = 1
-client_groups = 3
+client_groups = 4
 server_random_selection = false
 server_soft_limit = false
 
@@ -36,6 +36,19 @@ client_outstanding_ops = 32
 client_reservation = 0.0
 client_limit = 50.0
 client_weight = 2.0
+client_req_cost = 1
+
+[client.3]
+client_count = 1
+client_wait = 10
+client_total_ops = 2000
+client_server_select_range = 1
+client_iops_goal = 200
+client_outstanding_ops = 32
+client_reservation = 0.0
+client_limit = 50.0
+client_weight = 2.0
+client_req_cost = 3
 
 [server.0]
 server_count = 1

--- a/sim/src/config.cc
+++ b/sim/src/config.cc
@@ -175,6 +175,8 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
       ct.client_limit = std::stod(val);
     if (!cf.read(section, "client_weight", val))
       ct.client_weight = std::stod(val);
+    if (!cf.read(section, "client_req_cost", val))
+      ct.client_req_cost = std::stoul(val);
     g_conf.cli_group.push_back(ct);
   }
 

--- a/sim/src/config.h
+++ b/sim/src/config.h
@@ -23,6 +23,8 @@
 
 #include "ConfUtils.h"
 
+#include "sim_recs.h"
+
 
 namespace crimson {
   namespace qos_simulation {
@@ -37,6 +39,7 @@ namespace crimson {
       double client_reservation;
       double client_limit;
       double client_weight;
+      Cost client_req_cost;
 
       cli_group_t(uint _client_count = 100,
 		  uint _client_wait = 0,
@@ -46,7 +49,8 @@ namespace crimson {
 		  uint _client_outstanding_ops = 100,
 		  double _client_reservation = 20.0,
 		  double _client_limit = 60.0,
-		  double _client_weight = 1.0) :
+		  double _client_weight = 1.0,
+		  Cost _client_req_cost = 1u) :
 	client_count(_client_count),
 	client_wait(std::chrono::seconds(_client_wait)),
 	client_total_ops(_client_total_ops),
@@ -55,7 +59,8 @@ namespace crimson {
 	client_outstanding_ops(_client_outstanding_ops),
 	client_reservation(_client_reservation),
 	client_limit(_client_limit),
-	client_weight(_client_weight)
+	client_weight(_client_weight),
+	client_req_cost(_client_req_cost)
       {
 	// empty
       }
@@ -72,7 +77,8 @@ namespace crimson {
 	  std::fixed << std::setprecision(1) <<
 	  "client_reservation = " << cli_group.client_reservation << "\n" <<
 	  "client_limit = " << cli_group.client_limit << "\n" <<
-	  "client_weight = " << cli_group.client_weight;
+	  "client_weight = " << cli_group.client_weight << "\n" <<
+	  "client_req_cost = " << cli_group.client_req_cost;
 	return out;
       }
     }; // class cli_group_t

--- a/sim/src/sim_client.h
+++ b/sim/src/sim_client.h
@@ -112,6 +112,7 @@ namespace crimson {
 	TestResponse response;
 	ServerId     server_id;
 	RespPm       resp_params;
+	Cost         request_cost;
       };
 
       const ClientId id;
@@ -202,9 +203,11 @@ namespace crimson {
 
       void receive_response(const TestResponse& resp,
 			    const ServerId& server_id,
-			    const RespPm& resp_params) {
+			    const RespPm& resp_params,
+			    const Cost request_cost) {
 	RespGuard g(mtx_resp);
-	resp_queue.push_back(RespQueueItem{resp, server_id, resp_params});
+	resp_queue.push_back(
+	  RespQueueItem{ resp, server_id, resp_params, request_cost });
 	cv_resp.notify_one();
       }
 
@@ -300,7 +303,7 @@ namespace crimson {
 	    time_stats(internal_stats.mtx,
 		       internal_stats.track_resp_time,
 		       [&](){
-			 service_tracker.track_resp(item.server_id, item.resp_params);
+			 service_tracker.track_resp(item.server_id, item.resp_params, item.request_cost);
 		       });
 	    count_stats(internal_stats.mtx,
 			internal_stats.track_resp_count);

--- a/sim/src/sim_recs.h
+++ b/sim/src/sim_recs.h
@@ -38,6 +38,8 @@ using ServerId = uint;
 namespace crimson {
   namespace qos_simulation {
 
+    using Cost = uint32_t;
+
     inline void debugger() {
       raise(SIGCONT);
     }

--- a/sim/src/sim_server.h
+++ b/sim/src/sim_server.h
@@ -35,13 +35,16 @@ namespace crimson {
 	ClientId                     client;
 	std::unique_ptr<TestRequest> request;
 	RespPm                       additional;
+	Cost                         request_cost;
 
 	QueueItem(const ClientId&                _client,
 		  std::unique_ptr<TestRequest>&& _request,
-		  const RespPm&                  _additional) :
+		  const RespPm&                  _additional,
+		  const Cost                     _request_cost) :
 	  client(_client),
 	  request(std::move(_request)),
-	  additional(_additional)
+	  additional(_additional),
+	  request_cost(_request_cost)
 	{
 	  // empty
 	}
@@ -69,7 +72,8 @@ namespace crimson {
       using ClientRespFunc = std::function<void(ClientId,
 						const TestResponse&,
 						const ServerId&,
-						const RespPm&)>;
+						const RespPm&,
+						const Cost)>;
 
       using ServerAccumFunc = std::function<void(Accum& accumulator,
 						 const RespPm& additional)>;
@@ -105,7 +109,7 @@ namespace crimson {
 
       using CanHandleRequestFunc = std::function<bool(void)>;
       using HandleRequestFunc =
-	std::function<void(const ClientId&,std::unique_ptr<TestRequest>,const RespPm&)>;
+	std::function<void(const ClientId&,std::unique_ptr<TestRequest>,const RespPm&, uint64_t)>;
       using CreateQueueF = std::function<Q*(CanHandleRequestFunc,HandleRequestFunc)>;
 					
 
@@ -122,7 +126,8 @@ namespace crimson {
 						 this,
 						 std::placeholders::_1,
 						 std::placeholders::_2,
-						 std::placeholders::_3))),
+						 std::placeholders::_3,
+						 std::placeholders::_4))),
 	client_resp_f(_client_resp_f),
 	iops(_iops),
 	thread_pool_size(_thread_pool_size),
@@ -156,13 +161,16 @@ namespace crimson {
 
       void post(TestRequest&& request,
 		const ClientId& client_id,
-		const ReqPm& req_params)
+		const ReqPm& req_params,
+		const Cost request_cost)
       {
 	time_stats(internal_stats.mtx,
 		   internal_stats.add_request_time,
 		   [&](){
 		     priority_queue->add_request(std::move(request),
-						 client_id, req_params);
+						 client_id,
+						 req_params,
+						 request_cost);
 		   });
 	count_stats(internal_stats.mtx,
 		    internal_stats.add_request_count);
@@ -181,13 +189,15 @@ namespace crimson {
 
       void inner_post(const ClientId& client,
 		      std::unique_ptr<TestRequest> request,
-		      const RespPm& additional) {
+		      const RespPm& additional,
+		      const Cost request_cost) {
 	Lock l(inner_queue_mtx);
 	assert(!finishing);
 	accum_f(accumulator, additional);
 	inner_queue.emplace_back(QueueItem(client,
 					   std::move(request),
-					   additional));
+					   additional,
+					   request_cost));
 	inner_queue_cv.notify_one();
       }
 
@@ -202,17 +212,18 @@ namespace crimson {
 	    auto client = front.client;
 	    auto req = std::move(front.request);
 	    auto additional = front.additional;
+	    auto request_cost = front.request_cost;
 	    inner_queue.pop_front();
 
 	    l.unlock();
 
 	    // simulation operation by sleeping; then call function to
 	    // notify server of completion
-	    std::this_thread::sleep_for(op_time);
+	    std::this_thread::sleep_for(op_time * request_cost);
 
 	    // TODO: rather than assuming this constructor exists, perhaps
 	    // pass in a function that does this mapping?
-	    client_resp_f(client, TestResponse{req->epoch}, id, additional);
+	    client_resp_f(client, TestResponse{req->epoch}, id, additional, request_cost);
 
 	    time_stats(internal_stats.mtx,
 		       internal_stats.request_complete_time,

--- a/sim/src/ssched/ssched_client.h
+++ b/sim/src/ssched/ssched_client.h
@@ -34,11 +34,11 @@ namespace crimson {
 	// emptry
       }
 
-
-      void track_resp(const S& server_id, const NullData& ignore) {
+      void track_resp(const S& server_id,
+		      const NullData& ignore,
+		      uint64_t request_cost) {
 	// empty
       }
-
 
       /*
        * Returns the ReqParams for the given server.

--- a/sim/src/ssched/ssched_server.h
+++ b/sim/src/ssched/ssched_server.h
@@ -45,7 +45,7 @@ namespace crimson {
       // a function to submit a request to the server; the second
       // parameter is a callback when it's completed
       using HandleRequestFunc =
-	std::function<void(const C&,RequestRef,NullData)>;
+	std::function<void(const C&,RequestRef,NullData,uint64_t)>;
 
       struct PullReq {
 	enum class Type { returning, none };
@@ -111,14 +111,16 @@ namespace crimson {
 
       void add_request(R&& request,
 		       const C& client_id,
-		       const ReqParams& req_params) {
+		       const ReqParams& req_params,
+		       uint64_t request_cost) {
 	add_request(RequestRef(new R(std::move(request))),
-		    client_id, req_params);
+		    client_id, req_params, request_cost);
       }
 
       void add_request(RequestRef&& request,
 		       const C& client_id,
-		       const ReqParams& req_params) {
+		       const ReqParams& req_params,
+		       uint64_t request_cost) {
 	DataGuard g(queue_mtx);
 
 #ifdef PROFILE
@@ -183,7 +185,7 @@ namespace crimson {
 	if (!queue.empty() && can_handle_f()) {
 	  auto& front = queue.front();
 	  static NullData null_data;
-	  handle_f(front.client, std::move(front.request), null_data);
+	  handle_f(front.client, std::move(front.request), null_data, 1u);
 	  queue.pop_front();
 	}
       }

--- a/sim/src/test_dmclock.cc
+++ b/sim/src/test_dmclock.cc
@@ -12,6 +12,7 @@
  * COPYING.
  */
 
+#include <type_traits>
 
 #include "dmclock_recs.h"
 #include "dmclock_server.h"
@@ -25,6 +26,13 @@
 
 
 namespace test = crimson::test_dmc;
+
+
+// Note: if this static_assert fails then our two definitions of Cost
+// do not match; change crimson::qos_simulation::Cost to match the
+// definition of crimson::dmclock::Cost.
+static_assert(std::is_same<crimson::qos_simulation::Cost,crimson::dmclock::Cost>::value,
+	      "Please make sure the simulator type crimson::qos_simulation::Cost matches the dmclock type crimson::dmclock::Cost.");
 
 
 void test::dmc_server_accumulate_f(test::DmcAccum& a,

--- a/sim/src/test_dmclock.h
+++ b/sim/src/test_dmclock.h
@@ -36,7 +36,7 @@ namespace crimson {
     };
 
     using DmcQueue = dmc::PushPriorityQueue<ClientId,sim::TestRequest>;
-    using DmcServiceTracker = dmc::ServiceTracker<ServerId,dmc::BorrowingTracker>;
+    using DmcServiceTracker = dmc::ServiceTracker<ServerId,dmc::OrigTracker>;
 
     using DmcServer = sim::SimulatedServer<DmcQueue,
 					   dmc::ReqParams,

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -29,217 +29,223 @@ using namespace std::placeholders;
 
 
 namespace crimson {
-    namespace test_dmc {
-        void server_data(std::ostream& out,
-                         test::MySim* sim,
-                         test::MySim::ServerFilter server_disp_filter,
-                         int head_w, int data_w, int data_prec);
+  namespace test_dmc {
+    void server_data(std::ostream& out,
+		     test::MySim* sim,
+		     test::MySim::ServerFilter server_disp_filter,
+		     int head_w, int data_w, int data_prec);
 
-        void client_data(std::ostream& out,
-                         test::MySim* sim,
-                         test::MySim::ClientFilter client_disp_filter,
-                         int head_w, int data_w, int data_prec);
-    }
+    void client_data(std::ostream& out,
+		     test::MySim* sim,
+		     test::MySim::ClientFilter client_disp_filter,
+		     int head_w, int data_w, int data_prec);
+  }
 }
 
 
 int main(int argc, char* argv[]) {
-    std::vector<const char*> args;
-    for (int i = 1; i < argc; ++i) {
-      args.push_back(argv[i]);
+  std::vector<const char*> args;
+  for (int i = 1; i < argc; ++i) {
+    args.push_back(argv[i]);
+  }
+
+  std::string conf_file_list;
+  sim::ceph_argparse_early_args(args, &conf_file_list);
+
+  sim::sim_config_t g_conf;
+  std::vector<sim::cli_group_t> &cli_group = g_conf.cli_group;
+  std::vector<sim::srv_group_t> &srv_group = g_conf.srv_group;
+
+  if (!conf_file_list.empty()) {
+    int ret;
+    ret = sim::parse_config_file(conf_file_list, g_conf);
+    if (ret) {
+      // error
+      _exit(1);
     }
+  } else {
+    // default simulation parameter
+    g_conf.client_groups = 2;
 
-    std::string conf_file_list;
-    sim::ceph_argparse_early_args(args, &conf_file_list);
+    sim::srv_group_t st;
+    srv_group.push_back(st);
 
-    sim::sim_config_t g_conf;
-    std::vector<sim::cli_group_t> &cli_group = g_conf.cli_group;
-    std::vector<sim::srv_group_t> &srv_group = g_conf.srv_group;
+    sim::cli_group_t ct1(99, 0);
+    cli_group.push_back(ct1);
 
-    if (!conf_file_list.empty()) {
-      int ret;
-      ret = sim::parse_config_file(conf_file_list, g_conf);
-      if (ret) {
-	// error
-	_exit(1);
-      }
-    } else {
-      // default simulation parameter
-      g_conf.client_groups = 2;
+    sim::cli_group_t ct2(1, 10);
+    cli_group.push_back(ct2);
+  }
 
-      sim::srv_group_t st;
-      srv_group.push_back(st);
+  const uint server_groups = g_conf.server_groups;
+  const uint client_groups = g_conf.client_groups;
+  const bool server_random_selection = g_conf.server_random_selection;
+  const bool server_soft_limit = g_conf.server_soft_limit;
+  const double anticipation_timeout = g_conf.anticipation_timeout;
+  uint server_total_count = 0;
+  uint client_total_count = 0;
 
-      sim::cli_group_t ct1(99, 0);
-      cli_group.push_back(ct1);
+  for (uint i = 0; i < client_groups; ++i) {
+    client_total_count += cli_group[i].client_count;
+  }
 
-      sim::cli_group_t ct2(1, 10);
-      cli_group.push_back(ct2);
-    }
+  for (uint i = 0; i < server_groups; ++i) {
+    server_total_count += srv_group[i].server_count;
+  }
 
-    const uint server_groups = g_conf.server_groups;
-    const uint client_groups = g_conf.client_groups;
-    const bool server_random_selection = g_conf.server_random_selection;
-    const bool server_soft_limit = g_conf.server_soft_limit;
-    const double anticipation_timeout = g_conf.anticipation_timeout;
-    uint server_total_count = 0;
-    uint client_total_count = 0;
-
-    for (uint i = 0; i < client_groups; ++i) {
-      client_total_count += cli_group[i].client_count;
-    }
-
-    for (uint i = 0; i < server_groups; ++i) {
-      server_total_count += srv_group[i].server_count;
-    }
-
-    std::vector<test::dmc::ClientInfo> client_info;
-    for (uint i = 0; i < client_groups; ++i) {
-      client_info.push_back(test::dmc::ClientInfo 
+  std::vector<test::dmc::ClientInfo> client_info;
+  for (uint i = 0; i < client_groups; ++i) {
+    client_info.push_back(test::dmc::ClientInfo
 			  { cli_group[i].client_reservation,
-			    cli_group[i].client_weight,
-			    cli_group[i].client_limit } );
-    }
+			      cli_group[i].client_weight,
+			      cli_group[i].client_limit } );
+  }
 
-    auto ret_client_group_f = [&](const ClientId& c) -> uint {
-      uint group_max = 0;
-      uint i = 0;
-      for (; i < client_groups; ++i) {
-	group_max += cli_group[i].client_count;
-	if (c < group_max) {
-	  break;
-	}
-      }
-      return i;
-    };
-
-    auto ret_server_group_f = [&](const ServerId& s) -> uint {
-      uint group_max = 0;
-      uint i = 0;
-      for (; i < server_groups; ++i) {
-	group_max += srv_group[i].server_count;
-	if (s < group_max) {
-	  break;
-	}
-      }
-      return i;
-    };
-
-    auto client_info_f = [=](const ClientId& c) -> const test::dmc::ClientInfo* {
-      return &client_info[ret_client_group_f(c)];
-    };
-
-    auto client_disp_filter = [=] (const ClientId& i) -> bool {
-        return i < 3 || i >= (client_total_count - 3);
-    };
-
-    auto server_disp_filter = [=] (const ServerId& i) -> bool {
-        return i < 3 || i >= (server_total_count - 3);
-    };
-
-
-    test::MySim *simulation;
-  
-
-    // lambda to post a request to the identified server; called by client
-    test::SubmitFunc server_post_f =
-        [&simulation](const ServerId& server,
-                      sim::TestRequest&& request,
-                      const ClientId& client_id,
-                      const test::dmc::ReqParams& req_params) {
-        test::DmcServer& s = simulation->get_server(server);
-        s.post(std::move(request), client_id, req_params);
-    };
-
-    std::vector<std::vector<sim::CliInst>> cli_inst;
-    for (uint i = 0; i < client_groups; ++i) {
-      if (cli_group[i].client_wait == std::chrono::seconds(0)) {
-	cli_inst.push_back(
-	    { { sim::req_op, 
-	        (uint32_t)cli_group[i].client_total_ops,
-	        (double)cli_group[i].client_iops_goal, 
-	        (uint16_t)cli_group[i].client_outstanding_ops } } );
-      } else {
-	cli_inst.push_back(
-	    { { sim::wait_op, cli_group[i].client_wait },
-	      { sim::req_op, 
-	        (uint32_t)cli_group[i].client_total_ops,
-		(double)cli_group[i].client_iops_goal, 
-		(uint16_t)cli_group[i].client_outstanding_ops } } );
+  auto ret_client_group_f = [&](const ClientId& c) -> uint {
+    uint group_max = 0;
+    uint i = 0;
+    for (; i < client_groups; ++i) {
+      group_max += cli_group[i].client_count;
+      if (c < group_max) {
+	break;
       }
     }
+    return i;
+  };
 
-    simulation = new test::MySim();
-
-    test::DmcServer::ClientRespFunc client_response_f =
-        [&simulation](ClientId client_id,
-                      const sim::TestResponse& resp,
-                      const ServerId& server_id,
-                      const dmc::PhaseType& phase) {
-        simulation->get_client(client_id).receive_response(resp,
-                                                           server_id,
-                                                           phase);
-    };
-
-    test::CreateQueueF create_queue_f =
-        [&](test::DmcQueue::CanHandleRequestFunc can_f,
-            test::DmcQueue::HandleRequestFunc handle_f) -> test::DmcQueue* {
-        return new test::DmcQueue(client_info_f,
-                                  can_f,
-                                  handle_f,
-                                  server_soft_limit,
-                                  anticipation_timeout);
-    };
-
- 
-    auto create_server_f = [&](ServerId id) -> test::DmcServer* {
-      uint i = ret_server_group_f(id);
-      return new test::DmcServer(id,
-                                 srv_group[i].server_iops,
-				 srv_group[i].server_threads,
-				 client_response_f,
-				 test::dmc_server_accumulate_f,
-				 create_queue_f);
-    };
-
-    auto create_client_f = [&](ClientId id) -> test::DmcClient* {
-      uint i = ret_client_group_f(id);
-      test::MySim::ClientBasedServerSelectFunc server_select_f;
-      uint client_server_select_range = cli_group[i].client_server_select_range;
-      if (!server_random_selection) {
-	server_select_f = simulation->make_server_select_alt_range(client_server_select_range);
-      } else {
-	server_select_f = simulation->make_server_select_ran_range(client_server_select_range);
+  auto ret_server_group_f = [&](const ServerId& s) -> uint {
+    uint group_max = 0;
+    uint i = 0;
+    for (; i < server_groups; ++i) {
+      group_max += srv_group[i].server_count;
+      if (s < group_max) {
+	break;
       }
-      return new test::DmcClient(id,
-				 server_post_f,
-				 std::bind(server_select_f, _1, id),
-				 test::dmc_client_accumulate_f,
-				 cli_inst[i]);
-    };
+    }
+    return i;
+  };
+
+  auto client_info_f =
+    [=](const ClientId& c) -> const test::dmc::ClientInfo* {
+    return &client_info[ret_client_group_f(c)];
+  };
+
+  auto client_disp_filter = [=] (const ClientId& i) -> bool {
+    return i < 3 || i >= (client_total_count - 3);
+  };
+
+  auto server_disp_filter = [=] (const ServerId& i) -> bool {
+    return i < 3 || i >= (server_total_count - 3);
+  };
+
+
+  test::MySim *simulation;
+
+
+  // lambda to post a request to the identified server; called by client
+  test::SubmitFunc server_post_f =
+    [&simulation,
+     &cli_group,
+     &ret_client_group_f](const ServerId& server,
+			  sim::TestRequest&& request,
+			  const ClientId& client_id,
+			  const test::dmc::ReqParams& req_params) {
+    test::DmcServer& s = simulation->get_server(server);
+    sim::Cost request_cost = cli_group[ret_client_group_f(client_id)].client_req_cost;
+    s.post(std::move(request), client_id, req_params, request_cost);
+  };
+
+  std::vector<std::vector<sim::CliInst>> cli_inst;
+  for (uint i = 0; i < client_groups; ++i) {
+    if (cli_group[i].client_wait == std::chrono::seconds(0)) {
+      cli_inst.push_back(
+	{ { sim::req_op,
+	      (uint32_t)cli_group[i].client_total_ops,
+	      (double)cli_group[i].client_iops_goal,
+	      (uint16_t)cli_group[i].client_outstanding_ops } } );
+    } else {
+      cli_inst.push_back(
+	{ { sim::wait_op, cli_group[i].client_wait },
+	  { sim::req_op,
+	      (uint32_t)cli_group[i].client_total_ops,
+	      (double)cli_group[i].client_iops_goal,
+	      (uint16_t)cli_group[i].client_outstanding_ops } } );
+    }
+  }
+
+  simulation = new test::MySim();
+
+  test::DmcServer::ClientRespFunc client_response_f =
+    [&simulation](ClientId client_id,
+		  const sim::TestResponse& resp,
+		  const ServerId& server_id,
+		  const dmc::PhaseType& phase,
+		  const sim::Cost request_cost) {
+    simulation->get_client(client_id).receive_response(resp,
+						       server_id,
+						       phase,
+						       request_cost);
+  };
+
+  test::CreateQueueF create_queue_f =
+    [&](test::DmcQueue::CanHandleRequestFunc can_f,
+	test::DmcQueue::HandleRequestFunc handle_f) -> test::DmcQueue* {
+    return new test::DmcQueue(client_info_f,
+			      can_f,
+			      handle_f,
+			      server_soft_limit,
+			      anticipation_timeout);
+  };
+
+
+  auto create_server_f = [&](ServerId id) -> test::DmcServer* {
+    uint i = ret_server_group_f(id);
+    return new test::DmcServer(id,
+			       srv_group[i].server_iops,
+			       srv_group[i].server_threads,
+			       client_response_f,
+			       test::dmc_server_accumulate_f,
+			       create_queue_f);
+  };
+
+  auto create_client_f = [&](ClientId id) -> test::DmcClient* {
+    uint i = ret_client_group_f(id);
+    test::MySim::ClientBasedServerSelectFunc server_select_f;
+    uint client_server_select_range = cli_group[i].client_server_select_range;
+    if (!server_random_selection) {
+      server_select_f = simulation->make_server_select_alt_range(client_server_select_range);
+    } else {
+      server_select_f = simulation->make_server_select_ran_range(client_server_select_range);
+    }
+    return new test::DmcClient(id,
+			       server_post_f,
+			       std::bind(server_select_f, _1, id),
+			       test::dmc_client_accumulate_f,
+			       cli_inst[i]);
+  };
 
 #if 1
-    std::cout << "[global]" << std::endl << g_conf << std::endl;
-    for (uint i = 0; i < client_groups; ++i) {
-      std::cout << std::endl << "[client." << i << "]" << std::endl;
-      std::cout << cli_group[i] << std::endl;
-    }
-    for (uint i = 0; i < server_groups; ++i) {
-      std::cout << std::endl << "[server." << i << "]" << std::endl;
-      std::cout << srv_group[i] << std::endl;
-    }
-    std::cout << std::endl;
+  std::cout << "[global]" << std::endl << g_conf << std::endl;
+  for (uint i = 0; i < client_groups; ++i) {
+    std::cout << std::endl << "[client." << i << "]" << std::endl;
+    std::cout << cli_group[i] << std::endl;
+  }
+  for (uint i = 0; i < server_groups; ++i) {
+    std::cout << std::endl << "[server." << i << "]" << std::endl;
+    std::cout << srv_group[i] << std::endl;
+  }
+  std::cout << std::endl;
 #endif
 
-    simulation->add_servers(server_total_count, create_server_f);
-    simulation->add_clients(client_total_count, create_client_f);
+  simulation->add_servers(server_total_count, create_server_f);
+  simulation->add_clients(client_total_count, create_client_f);
 
-    simulation->run();
-    simulation->display_stats(std::cout,
-                              &test::server_data, &test::client_data,
-                              server_disp_filter, client_disp_filter);
+  simulation->run();
+  simulation->display_stats(std::cout,
+			    &test::server_data, &test::client_data,
+			    server_disp_filter, client_disp_filter);
 
-    delete simulation;
+  delete simulation;
 } // main
 
 
@@ -247,32 +253,32 @@ void test::client_data(std::ostream& out,
 		       test::MySim* sim,
 		       test::MySim::ClientFilter client_disp_filter,
 		       int head_w, int data_w, int data_prec) {
-    // report how many ops were done by reservation and proportion for
-    // each client
+  // report how many ops were done by reservation and proportion for
+  // each client
 
-    int total_r = 0;
-    out << std::setw(head_w) << "res_ops:";
-    for (uint i = 0; i < sim->get_client_count(); ++i) {
-        const auto& client = sim->get_client(i);
-        auto r = client.get_accumulator().reservation_count;
-        total_r += r;
-        if (!client_disp_filter(i)) continue;
-        out << " " << std::setw(data_w) << r;
-    }
-    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
-        std::fixed << total_r << std::endl;
+  int total_r = 0;
+  out << std::setw(head_w) << "res_ops:";
+  for (uint i = 0; i < sim->get_client_count(); ++i) {
+    const auto& client = sim->get_client(i);
+    auto r = client.get_accumulator().reservation_count;
+    total_r += r;
+    if (!client_disp_filter(i)) continue;
+    out << " " << std::setw(data_w) << r;
+  }
+  out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
+    std::fixed << total_r << std::endl;
 
-    int total_p = 0;
-    out << std::setw(head_w) << "prop_ops:";
-    for (uint i = 0; i < sim->get_client_count(); ++i) {
-        const auto& client = sim->get_client(i);
-        auto p = client.get_accumulator().proportion_count;
-        total_p += p;
-        if (!client_disp_filter(i)) continue;
-        out << " " << std::setw(data_w) << p;
-    }
-    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
-        std::fixed << total_p << std::endl;
+  int total_p = 0;
+  out << std::setw(head_w) << "prop_ops:";
+  for (uint i = 0; i < sim->get_client_count(); ++i) {
+    const auto& client = sim->get_client(i);
+    auto p = client.get_accumulator().proportion_count;
+    total_p += p;
+    if (!client_disp_filter(i)) continue;
+    out << " " << std::setw(data_w) << p;
+  }
+  out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
+    std::fixed << total_p << std::endl;
 }
 
 
@@ -280,57 +286,57 @@ void test::server_data(std::ostream& out,
 		       test::MySim* sim,
 		       test::MySim::ServerFilter server_disp_filter,
 		       int head_w, int data_w, int data_prec) {
-    out << std::setw(head_w) << "res_ops:";
-    int total_r = 0;
-    for (uint i = 0; i < sim->get_server_count(); ++i) {
-        const auto& server = sim->get_server(i);
-        auto rc = server.get_accumulator().reservation_count;
-        total_r += rc;
-        if (!server_disp_filter(i)) continue;
-        out << " " << std::setw(data_w) << rc;
-    }
-    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
-        std::fixed << total_r << std::endl;
+  out << std::setw(head_w) << "res_ops:";
+  int total_r = 0;
+  for (uint i = 0; i < sim->get_server_count(); ++i) {
+    const auto& server = sim->get_server(i);
+    auto rc = server.get_accumulator().reservation_count;
+    total_r += rc;
+    if (!server_disp_filter(i)) continue;
+    out << " " << std::setw(data_w) << rc;
+  }
+  out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
+    std::fixed << total_r << std::endl;
 
-    out << std::setw(head_w) << "prop_ops:";
-    int total_p = 0;
-    for (uint i = 0; i < sim->get_server_count(); ++i) {
-        const auto& server = sim->get_server(i);
-        auto pc = server.get_accumulator().proportion_count;
-        total_p += pc;
-        if (!server_disp_filter(i)) continue;
-        out << " " << std::setw(data_w) << pc;
-    }
-    out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
-        std::fixed << total_p << std::endl;
+  out << std::setw(head_w) << "prop_ops:";
+  int total_p = 0;
+  for (uint i = 0; i < sim->get_server_count(); ++i) {
+    const auto& server = sim->get_server(i);
+    auto pc = server.get_accumulator().proportion_count;
+    total_p += pc;
+    if (!server_disp_filter(i)) continue;
+    out << " " << std::setw(data_w) << pc;
+  }
+  out << " " << std::setw(data_w) << std::setprecision(data_prec) <<
+    std::fixed << total_p << std::endl;
 
-    const auto& q = sim->get_server(0).get_priority_queue();
-    out << std::endl <<
-	" k-way heap: " << q.get_heap_branching_factor() << std::endl
-	<< std::endl;
+  const auto& q = sim->get_server(0).get_priority_queue();
+  out << std::endl <<
+    " k-way heap: " << q.get_heap_branching_factor() << std::endl
+      << std::endl;
 
 #ifdef PROFILE
-    crimson::ProfileCombiner<std::chrono::nanoseconds> art_combiner;
-    crimson::ProfileCombiner<std::chrono::nanoseconds> rct_combiner;
-    for (uint i = 0; i < sim->get_server_count(); ++i) {
-      const auto& q = sim->get_server(i).get_priority_queue();
-      const auto& art = q.add_request_timer;
-      art_combiner.combine(art);
-      const auto& rct = q.request_complete_timer;
-      rct_combiner.combine(rct);
-    }
-    out << "Server add_request_timer: count:" << art_combiner.get_count() <<
-      ", mean:" << art_combiner.get_mean() <<
-      ", std_dev:" << art_combiner.get_std_dev() <<
-      ", low:" << art_combiner.get_low() <<
-      ", high:" << art_combiner.get_high() << std::endl;
-    out << "Server request_complete_timer: count:" << rct_combiner.get_count() <<
-      ", mean:" << rct_combiner.get_mean() <<
-      ", std_dev:" << rct_combiner.get_std_dev() <<
-      ", low:" << rct_combiner.get_low() <<
-      ", high:" << rct_combiner.get_high() << std::endl;
-    out << "Server combined mean: " <<
-      (art_combiner.get_mean() + rct_combiner.get_mean()) <<
-      std::endl;
+  crimson::ProfileCombiner<std::chrono::nanoseconds> art_combiner;
+  crimson::ProfileCombiner<std::chrono::nanoseconds> rct_combiner;
+  for (uint i = 0; i < sim->get_server_count(); ++i) {
+    const auto& q = sim->get_server(i).get_priority_queue();
+    const auto& art = q.add_request_timer;
+    art_combiner.combine(art);
+    const auto& rct = q.request_complete_timer;
+    rct_combiner.combine(rct);
+  }
+  out << "Server add_request_timer: count:" << art_combiner.get_count() <<
+    ", mean:" << art_combiner.get_mean() <<
+    ", std_dev:" << art_combiner.get_std_dev() <<
+    ", low:" << art_combiner.get_low() <<
+    ", high:" << art_combiner.get_high() << std::endl;
+  out << "Server request_complete_timer: count:" << rct_combiner.get_count() <<
+    ", mean:" << rct_combiner.get_mean() <<
+    ", std_dev:" << rct_combiner.get_std_dev() <<
+    ", low:" << rct_combiner.get_low() <<
+    ", high:" << rct_combiner.get_high() << std::endl;
+  out << "Server combined mean: " <<
+    (art_combiner.get_mean() + rct_combiner.get_mean()) <<
+    std::endl;
 #endif
 }

--- a/sim/src/test_ssched_main.cc
+++ b/sim/src/test_ssched_main.cc
@@ -41,6 +41,9 @@ namespace crimson {
 		     int head_w, int data_w, int data_prec);
   } // namespace test_simple
 } // namespace crimson
+
+
+using Cost = uint32_t;
     
 
 int main(int argc, char* argv[]) {
@@ -78,7 +81,7 @@ int main(int argc, char* argv[]) {
 		  const ClientId& client_id,
 		  const ssched::ReqParams& req_params) {
     auto& server = simulation->get_server(server_id);
-    server.post(std::move(request), client_id, req_params);
+    server.post(std::move(request), client_id, req_params, 1u);
   };
 
   static std::vector<sim::CliInst> no_wait =
@@ -104,10 +107,12 @@ int main(int argc, char* argv[]) {
     [&simulation](ClientId client_id,
 		  const sim::TestResponse& resp,
 		  const ServerId& server_id,
-		  const ssched::NullData& resp_params) {
+		  const ssched::NullData& resp_params,
+		  Cost request_cost) {
     simulation->get_client(client_id).receive_response(resp,
 						       server_id,
-						       resp_params);
+						       resp_params,
+						       request_cost);
   };
 
   test::CreateQueueF create_queue_f =

--- a/src/dmclock_recs.h
+++ b/src/dmclock_recs.h
@@ -24,6 +24,12 @@ namespace crimson {
   namespace dmclock {
     using Counter = uint64_t;
 
+    // we're abstracting cost to its own type to better allow for
+    // future changes; we're assuming that Cost is relatively small
+    // and that it would be more efficient to pass-by-value than
+    // by-reference.
+    using Cost = uint32_t;
+
     enum class PhaseType : uint8_t { reservation, priority };
 
     inline std::ostream& operator<<(std::ostream& out, const PhaseType& phase) {
@@ -32,21 +38,21 @@ namespace crimson {
     }
 
     struct ReqParams {
-      // count of all replies since last request; MUSTN'T BE 0
+      // count of all replies since last request
       uint32_t delta;
 
-      // count of reservation replies since last request; MUSTN'T BE 0
+      // count of reservation replies since last request
       uint32_t rho;
 
       ReqParams(uint32_t _delta, uint32_t _rho) :
 	delta(_delta),
 	rho(_rho)
       {
-	assert(0 != delta && 0 != rho && rho <= delta);
+	assert(rho <= delta);
       }
 
       ReqParams() :
-	ReqParams(1, 1)
+	ReqParams(0, 0)
       {
 	// empty
       }

--- a/test/test_dmclock_client.cc
+++ b/test/test_dmclock_client.cc
@@ -105,7 +105,7 @@ namespace crimson {
     } // TEST
 
 
-    TEST(dmclock_client, delta_rho_values) {
+    TEST(dmclock_client, delta_rho_values_borrowing_tracker) {
       using ServerId = int;
       // using ClientId = int;
 
@@ -115,8 +115,8 @@ namespace crimson {
 
       // RespParams<ServerId> resp_params(server, dmc::PhaseType::reservation);
 
-      dmc::ServiceTracker<ServerId> st(std::chrono::seconds(2),
-                                       std::chrono::seconds(3));
+      dmc::ServiceTracker<ServerId,dmc::BorrowingTracker> st(std::chrono::seconds(2),
+							     std::chrono::seconds(3));
       auto rp1 = st.get_req_params(server1);
 
       EXPECT_EQ(1u, rp1.delta) <<
@@ -136,7 +136,7 @@ namespace crimson {
 	"other servers";
 
       // RESPONSE
-      st.track_resp(server1, dmc::PhaseType::priority);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
 
       auto rp3 = st.get_req_params(server1);
 
@@ -148,7 +148,7 @@ namespace crimson {
 	"other servers";
 
       // RESPONSE
-      st.track_resp(server2, dmc::PhaseType::priority);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
 
       auto rp4 = st.get_req_params(server1);
 
@@ -169,7 +169,7 @@ namespace crimson {
 	"other servers";
 
       // RESPONSE
-      st.track_resp(server2, dmc::PhaseType::reservation);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
 
       auto rp6 = st.get_req_params(server1);
 
@@ -180,13 +180,13 @@ namespace crimson {
 	"rho should be 2 with one intervening reservation responses by " <<
 	"another server";
 
-      st.track_resp(server2, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::priority);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
 
       auto rp7 = st.get_req_params(server1);
 
@@ -228,7 +228,7 @@ namespace crimson {
     // NB: the BorrowingTracker has not been fully tested and the
     // expected values below have not yet been compared with the
     // theoretically correct values.
-    TEST(dmclock_client, orig_tracker_delta_rho_values) {
+    TEST(dmclock_client, delta_rho_values_orig_tracker) {
       using ServerId = int;
 
       ServerId server1 = 101;
@@ -244,63 +244,63 @@ namespace crimson {
 
       auto rp2 = st.get_req_params(server1);
 
-      EXPECT_EQ(1u, rp2.delta);
-      EXPECT_EQ(1u, rp2.rho);
+      EXPECT_EQ(0u, rp2.delta);
+      EXPECT_EQ(0u, rp2.rho);
 
-      st.track_resp(server1, dmc::PhaseType::priority);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
 
       auto rp3 = st.get_req_params(server1);
 
-      EXPECT_EQ(1u, rp3.delta);
-      EXPECT_EQ(1u, rp3.rho);
+      EXPECT_EQ(0u, rp3.delta);
+      EXPECT_EQ(0u, rp3.rho);
 
-      st.track_resp(server2, dmc::PhaseType::priority);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
 
       auto rp4 = st.get_req_params(server1);
 
-      EXPECT_EQ(2u, rp4.delta);
-      EXPECT_EQ(1u, rp4.rho);
+      EXPECT_EQ(1u, rp4.delta);
+      EXPECT_EQ(0u, rp4.rho);
 
       auto rp5 = st.get_req_params(server1);
 
-      EXPECT_EQ(1u, rp5.delta);
-      EXPECT_EQ(1u, rp5.rho);
+      EXPECT_EQ(0u, rp5.delta);
+      EXPECT_EQ(0u, rp5.rho);
 
-      st.track_resp(server2, dmc::PhaseType::reservation);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
 
       auto rp6 = st.get_req_params(server1);
 
-      EXPECT_EQ(2u, rp6.delta);
-      EXPECT_EQ(2u, rp6.rho);
+      EXPECT_EQ(1u, rp6.delta);
+      EXPECT_EQ(1u, rp6.rho);
 
       // auto rp6_b = st.get_req_params(server2);
 
-      st.track_resp(server2, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::reservation);
-      st.track_resp(server1, dmc::PhaseType::priority);
-      st.track_resp(server2, dmc::PhaseType::priority);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::reservation, 1u);
+      st.track_resp(server1, dmc::PhaseType::priority, 1u);
+      st.track_resp(server2, dmc::PhaseType::priority, 1u);
 
       auto rp7 = st.get_req_params(server1);
 
-      EXPECT_EQ(5u, rp7.delta);
-      EXPECT_EQ(3u, rp7.rho);
+      EXPECT_EQ(4u, rp7.delta);
+      EXPECT_EQ(2u, rp7.rho);
 
       auto rp7b = st.get_req_params(server2);
 
-      EXPECT_EQ(4u, rp7b.delta);
-      EXPECT_EQ(2u, rp7b.rho);
+      EXPECT_EQ(3u, rp7b.delta);
+      EXPECT_EQ(1u, rp7b.rho);
 
       auto rp8 = st.get_req_params(server1);
 
-      EXPECT_EQ(1u, rp8.delta);
-      EXPECT_EQ(1u, rp8.rho);
+      EXPECT_EQ(0u, rp8.delta);
+      EXPECT_EQ(0u, rp8.rho);
 
       auto rp8b = st.get_req_params(server2);
-      EXPECT_EQ(1u, rp8b.delta);
-      EXPECT_EQ(1u, rp8b.rho);
+      EXPECT_EQ(0u, rp8b.delta);
+      EXPECT_EQ(0u, rp8b.rho);
     } // TEST
 
   } // namespace dmclock

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -105,7 +105,8 @@ namespace crimson {
       auto server_ready_f = [] () -> bool { return true; };
       auto submit_req_f = [] (const ClientId& c,
 			      std::unique_ptr<Request> req,
-			      dmc::PhaseType phase) {
+			      dmc::PhaseType phase,
+			      uint64_t req_cost) {
 	// empty; do nothing
       };
 
@@ -865,7 +866,7 @@ namespace crimson {
 
       QueueRef pq(new Queue(client_info_f, false));
 
-      ReqParams req_params(1,1);
+      ReqParams req_params(0, 0);
 
       // make sure all times are well before now
       auto start_time = dmc::get_time() - 100.0;

--- a/test/test_test_client.cc
+++ b/test/test_test_client.cc
@@ -45,6 +45,7 @@ TEST(test_client, full_bore_timing) {
   sim::TestResponse resp(0);
   dmc::PhaseType resp_params = dmc::PhaseType::priority;
   test::DmcClient* client;
+  const sim::Cost request_cost = 1u;
 
   auto start = now();
   client =
@@ -54,7 +55,7 @@ TEST(test_client, full_bore_timing) {
 			     const ClientId& client_id,
 			     const dmc::ReqParams& req_params) {
 			  ++count;
-			  client->receive_response(resp, client_id, resp_params);
+			  client->receive_response(resp, client_id, resp_params, request_cost);
 			},
 			[&] (const uint64_t seed) -> ServerId& {
 			  return server_id;
@@ -85,6 +86,7 @@ TEST(test_client, paused_timing) {
 
   sim::TestResponse resp(0);
   dmc::PhaseType resp_params = dmc::PhaseType::priority;
+  const uint64_t request_cost = 1u;
   test::DmcClient* client;
 
   auto start = now();
@@ -96,7 +98,7 @@ TEST(test_client, paused_timing) {
 			     const dmc::ReqParams& req_params) {
 			  ++count;
 			  if (auto_respond.load()) {
-			    client->receive_response(resp, client_id, resp_params);
+			    client->receive_response(resp, client_id, resp_params, request_cost);
 			  } else {
 			    ++unresponded_count;
 			  }
@@ -116,7 +118,7 @@ TEST(test_client, paused_timing) {
       auto_respond = true;
       // respond to those 50 calls
       for(int i = 0; i < 50; ++i) {
-	client->receive_response(resp, my_client_id, resp_params);
+	client->receive_response(resp, my_client_id, resp_params, 1);
 	--unresponded_count;
       }
     });


### PR DESCRIPTION
Allow the dmclock library to handle the "cost" of an operation/request. This is in contrast to just measuring ops. If the cost is set at the value 1, then it's equivalent to the old code.

The cost is calculated on the server side and affects the tag values for the request. Furthermore, the cost is then sent back to the client, so the ServiceTracker can use the cost to properly calculate delta and rho values.

We now allow the delta and rho values sent with a request to be zero, since the request cost is included on the server-side tag calculation, and the request cost must be positive guaranteeing the advancement of tags.

The OrigTracker has now been updated so as not to add one when computing delta and rho.

The unit tests have been updated to use request costs. And the simulator has been updated to use cost, and the cost of a client group's requests can be configured.

The simulation has been changed to user the OrigTracker as the default tracker.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>