### PR TITLE
PriorityQueueBase uses RequestRef&& for remove_by callbacks

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -379,12 +379,12 @@ namespace crimson {
 
 	// NB: because a deque is the underlying structure, this
 	// operation might be expensive
-	bool remove_by_req_filter_fw(std::function<bool(R&&)> filter_accum) {
+	bool remove_by_req_filter_fw(std::function<bool(RequestRef&&)> filter_accum) {
 	  bool any_removed = false;
 	  for (auto i = requests.begin();
 	       i != requests.end();
 	       /* no inc */) {
-	    if (filter_accum(std::move(*i->request))) {
+	    if (filter_accum(std::move(i->request))) {
 	      any_removed = true;
 	      i = requests.erase(i);
 	    } else {
@@ -396,12 +396,12 @@ namespace crimson {
 
 	// NB: because a deque is the underlying structure, this
 	// operation might be expensive
-	bool remove_by_req_filter_bw(std::function<bool(R&&)> filter_accum) {
+	bool remove_by_req_filter_bw(std::function<bool(RequestRef&&)> filter_accum) {
 	  bool any_removed = false;
 	  for (auto i = requests.rbegin();
 	       i != requests.rend();
 	       /* no inc */) {
-	    if (filter_accum(std::move(*i->request))) {
+	    if (filter_accum(std::move(i->request))) {
 	      any_removed = true;
 	      i = decltype(i){ requests.erase(std::next(i).base()) };
 	    } else {
@@ -412,7 +412,7 @@ namespace crimson {
 	}
 
 	inline bool
-	remove_by_req_filter(std::function<bool(R&&)> filter_accum,
+	remove_by_req_filter(std::function<bool(RequestRef&&)> filter_accum,
 			     bool visit_backwards) {
 	  if (visit_backwards) {
 	    return remove_by_req_filter_bw(filter_accum);
@@ -506,7 +506,7 @@ namespace crimson {
       }
 
 
-      bool remove_by_req_filter(std::function<bool(R&&)> filter_accum,
+      bool remove_by_req_filter(std::function<bool(RequestRef&&)> filter_accum,
 				bool visit_backwards = false) {
 	bool any_removed = false;
 	DataGuard g(data_mtx);
@@ -528,14 +528,14 @@ namespace crimson {
 
 
       // use as a default value when no accumulator is provide
-      static void request_sink(R&& req) {
+      static void request_sink(RequestRef&& req) {
 	// do nothing
       }
 
 
       void remove_by_client(const C& client,
 			    bool reverse = false,
-			    std::function<void (R&&)> accum = request_sink) {
+			    std::function<void (RequestRef&&)> accum = request_sink) {
 	DataGuard g(data_mtx);
 
 	auto i = client_map.find(client);
@@ -546,13 +546,13 @@ namespace crimson {
 	  for (auto j = i->second->requests.rbegin();
 	       j != i->second->requests.rend();
 	       ++j) {
-	    accum(std::move(*j->request));
+	    accum(std::move(j->request));
 	  }
 	} else {
 	  for (auto j = i->second->requests.begin();
 	       j != i->second->requests.end();
 	       ++j) {
-	    accum(std::move(*j->request));
+	    accum(std::move(j->request));
 	  }
 	}
 

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -247,6 +247,7 @@ namespace crimson {
 
       using ClientId = int;
       using Queue = dmc::PullPriorityQueue<ClientId,MyReq>;
+      using MyReqRef = typename Queue::RequestRef;
 
       ClientId client1 = 17;
       ClientId client2 = 98;
@@ -277,15 +278,15 @@ namespace crimson {
       EXPECT_EQ(2u, pq.client_count());
       EXPECT_EQ(9u, pq.request_count());
 
-      pq.remove_by_req_filter([](const MyReq& r) -> bool {return 1 == r.id % 2;});
+      pq.remove_by_req_filter([](MyReqRef&& r) -> bool {return 1 == r->id % 2;});
 
       EXPECT_EQ(5u, pq.request_count());
 
       std::list<MyReq> capture;
       pq.remove_by_req_filter(
-	[&capture] (const MyReq& r) -> bool {
-	  if (0 == r.id % 2) {
-	    capture.push_front(r);
+	[&capture] (MyReqRef&& r) -> bool {
+	  if (0 == r->id % 2) {
+	    capture.push_front(*r);
 	    return true;
 	  } else {
 	    return false;
@@ -316,6 +317,7 @@ namespace crimson {
 
       using ClientId = int;
       using Queue = dmc::PullPriorityQueue<ClientId,MyReq>;
+      using MyReqRef = typename Queue::RequestRef;
 
       ClientId client1 = 17;
 
@@ -346,9 +348,9 @@ namespace crimson {
 
       std::vector<MyReq> capture;
       pq.remove_by_req_filter(
-	[&capture] (const MyReq& r) -> bool {
-	  if (1 == r.id % 2) {
-	    capture.push_back(r);
+	[&capture] (MyReqRef&& r) -> bool {
+	  if (1 == r->id % 2) {
+	    capture.push_back(*r);
 	    return true;
 	  } else {
 	    return false;
@@ -367,9 +369,9 @@ namespace crimson {
 
       std::vector<MyReq> capture2;
       pq.remove_by_req_filter(
-	[&capture2] (const MyReq& r) -> bool {
-	  if (0 == r.id % 2) {
-	    capture2.insert(capture2.begin(), r);
+	[&capture2] (MyReqRef&& r) -> bool {
+	  if (0 == r->id % 2) {
+	    capture2.insert(capture2.begin(), *r);
 	    return true;
 	  } else {
 	    return false;
@@ -398,6 +400,7 @@ namespace crimson {
 
       using ClientId = int;
       using Queue = dmc::PullPriorityQueue<ClientId,MyReq>;
+      using MyReqRef = typename Queue::RequestRef;
 
       ClientId client1 = 17;
 
@@ -428,9 +431,9 @@ namespace crimson {
 
       std::vector<MyReq> capture;
       pq.remove_by_req_filter(
-	[&capture] (const MyReq& r) -> bool {
-	  if (1 == r.id % 2) {
-	    capture.insert(capture.begin(), r);
+	[&capture] (MyReqRef&& r) -> bool {
+	  if (1 == r->id % 2) {
+	    capture.insert(capture.begin(), *r);
 	    return true;
 	  } else {
 	    return false;
@@ -448,9 +451,9 @@ namespace crimson {
 
       std::vector<MyReq> capture2;
       pq.remove_by_req_filter(
-	[&capture2] (const MyReq& r) -> bool {
-	  if (0 == r.id % 2) {
-	    capture2.push_back(r);
+	[&capture2] (MyReqRef&& r) -> bool {
+	  if (0 == r->id % 2) {
+	    capture2.push_back(*r);
 	    return true;
 	  } else {
 	    return false;
@@ -479,6 +482,7 @@ namespace crimson {
 
       using ClientId = int;
       using Queue = dmc::PullPriorityQueue<ClientId,MyReq>;
+      using MyReqRef = typename Queue::RequestRef;
 
       ClientId client1 = 17;
       ClientId client2 = 98;
@@ -513,8 +517,8 @@ namespace crimson {
 
       pq.remove_by_client(client1,
 			  true,
-			  [&removed] (const MyReq& r) {
-			    removed.push_front(r);
+			  [&removed] (MyReqRef&& r) {
+			    removed.push_front(*r);
 			  });
 
       EXPECT_EQ(3u, removed.size());


### PR DESCRIPTION
if a caller allocates their own R and passes it as a RequestRef into
PullPriorityQueue::add_request(), they should get that same pointer back
from the callbacks used by PriorityQueueBase::remove_by_*()

this is important if the request was instead allocated as some type
derived from R - in that case, the callback with R&& only gives back
part of the original object