### PR TITLE
add option to reject requests to clients over limit

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -72,7 +72,8 @@ namespace crimson {
       // are met and below their limits
       Allow,
       // if an incoming request would exceed its limit, add_request() will
-      // reject it with EAGAIN instead of adding it to the queue
+      // reject it with EAGAIN instead of adding it to the queue. cannot be used
+      // with DelayedTagCalc, because add_request() needs an accurate tag
       Reject,
     };
 
@@ -797,6 +798,8 @@ namespace crimson {
       {
 	assert(_erase_age >= _idle_age);
 	assert(_check_time < _idle_age);
+	// AtLimit::Reject depends on ImmediateTagCalc
+	assert(at_limit != AtLimit::Reject || !IsDelayed);
 	cleaning_job =
 	  std::unique_ptr<RunEvery>(
 	    new RunEvery(check_time,

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -846,11 +846,11 @@ namespace crimson {
       }
 
       // data_mtx must be held by caller
-      void do_add_request(RequestRef&& request,
-			  const C& client_id,
-			  const ReqParams& req_params,
-			  const Time time,
-			  const Cost cost = 1u) {
+      int do_add_request(RequestRef&& request,
+			 const C& client_id,
+			 const ReqParams& req_params,
+			 const Time time,
+			 const Cost cost = 1u) {
 	++tick;
 
         auto insert = client_map.emplace(client_id, ClientRecRef{});
@@ -944,7 +944,8 @@ namespace crimson {
 #if USE_PROP_HEAP
 	prop_heap.adjust(client);
 #endif
-      } // add_request
+	return 0;
+      } // do_add_request
 
       // data_mtx must be held by caller
       void update_next_tag(DelayedTagCalc delayed, ClientRec& top,
@@ -1248,78 +1249,79 @@ namespace crimson {
       }
 
 
-      inline void add_request(R&& request,
-			      const C& client_id,
-			      const ReqParams& req_params,
-			      const Cost cost = 1u) {
-	add_request(typename super::RequestRef(new R(std::move(request))),
-		    client_id,
-		    req_params,
-		    get_time(),
-		    cost);
+      int add_request(R&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Cost cost = 1u) {
+	return add_request(typename super::RequestRef(new R(std::move(request))),
+			   client_id,
+			   req_params,
+			   get_time(),
+			   cost);
       }
 
 
-      inline void add_request(R&& request,
-			      const C& client_id,
-			      const Cost cost = 1u) {
+      int add_request(R&& request,
+		      const C& client_id,
+		      const Cost cost = 1u) {
 	static const ReqParams null_req_params;
-	add_request(typename super::RequestRef(new R(std::move(request))),
-		    client_id,
-		    null_req_params,
-		    get_time(),
-		    cost);
+	return add_request(typename super::RequestRef(new R(std::move(request))),
+			   client_id,
+			   null_req_params,
+			   get_time(),
+			   cost);
       }
 
 
-      inline void add_request_time(R&& request,
-				   const C& client_id,
-				   const ReqParams& req_params,
-				   const Time time,
-				   const Cost cost = 1u) {
-	add_request(typename super::RequestRef(new R(std::move(request))),
-		    client_id,
-		    req_params,
-		    time,
-		    cost);
+      int add_request_time(R&& request,
+			   const C& client_id,
+			   const ReqParams& req_params,
+			   const Time time,
+			   const Cost cost = 1u) {
+	return add_request(typename super::RequestRef(new R(std::move(request))),
+			   client_id,
+			   req_params,
+			   time,
+			   cost);
       }
 
 
-      inline void add_request(typename super::RequestRef&& request,
-			      const C& client_id,
-			      const ReqParams& req_params,
-			      const Cost cost = 1u) {
-	add_request(request, req_params, client_id, get_time(), cost);
+      int add_request(typename super::RequestRef&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Cost cost = 1u) {
+	return add_request(request, req_params, client_id, get_time(), cost);
       }
 
 
-      inline void add_request(typename super::RequestRef&& request,
-			      const C& client_id,
-			      const Cost cost = 1u) {
+      int add_request(typename super::RequestRef&& request,
+		      const C& client_id,
+		      const Cost cost = 1u) {
 	static const ReqParams null_req_params;
-	add_request(request, null_req_params, client_id, get_time(), cost);
+	return add_request(request, null_req_params, client_id, get_time(), cost);
       }
 
 
       // this does the work; the versions above provide alternate interfaces
-      void add_request(typename super::RequestRef&& request,
-		       const C& client_id,
-		       const ReqParams& req_params,
-		       const Time time,
-		       const Cost cost = 1u) {
+      int add_request(typename super::RequestRef&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Time time,
+		      const Cost cost = 1u) {
 	typename super::DataGuard g(this->data_mtx);
 #ifdef PROFILE
 	add_request_timer.start();
 #endif
-	super::do_add_request(std::move(request),
-			      client_id,
-			      req_params,
-			      time,
-			      cost);
+	int r = super::do_add_request(std::move(request),
+				      client_id,
+				      req_params,
+				      time,
+				      cost);
 	// no call to schedule_request for pull version
 #ifdef PROFILE
 	add_request_timer.stop();
 #endif
+	return r;
       }
 
 
@@ -1493,57 +1495,60 @@ namespace crimson {
 
     public:
 
-      inline void add_request(R&& request,
-			      const C& client_id,
-			      const ReqParams& req_params,
-			      const Cost cost = 1u) {
-	add_request(typename super::RequestRef(new R(std::move(request))),
-		    client_id,
-		    req_params,
-		    get_time(),
-		    cost);
+      int add_request(R&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Cost cost = 1u) {
+	return add_request(typename super::RequestRef(new R(std::move(request))),
+			   client_id,
+			   req_params,
+			   get_time(),
+			   cost);
       }
 
 
-      inline void add_request(typename super::RequestRef&& request,
-			      const C& client_id,
-			      const ReqParams& req_params,
-			      const Cost cost = 1u) {
-	add_request(request, req_params, client_id, get_time(), cost);
+      int add_request(typename super::RequestRef&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Cost cost = 1u) {
+	return add_request(request, req_params, client_id, get_time(), cost);
       }
 
 
-      inline void add_request_time(const R& request,
-				   const C& client_id,
-				   const ReqParams& req_params,
-				   const Time time,
-				   const Cost cost = 1u) {
-	add_request(typename super::RequestRef(new R(request)),
-		    client_id,
-		    req_params,
-		    time,
-		    cost);
+      int add_request_time(const R& request,
+			   const C& client_id,
+			   const ReqParams& req_params,
+			   const Time time,
+			   const Cost cost = 1u) {
+	return add_request(typename super::RequestRef(new R(request)),
+			   client_id,
+			   req_params,
+			   time,
+			   cost);
       }
 
 
-      void add_request(typename super::RequestRef&& request,
-		       const C& client_id,
-		       const ReqParams& req_params,
-		       const Time time,
-		       const Cost cost = 1u) {
+      int add_request(typename super::RequestRef&& request,
+		      const C& client_id,
+		      const ReqParams& req_params,
+		      const Time time,
+		      const Cost cost = 1u) {
 	typename super::DataGuard g(this->data_mtx);
 #ifdef PROFILE
 	add_request_timer.start();
 #endif
-	super::do_add_request(std::move(request),
-			      client_id,
-			      req_params,
-			      time,
-			      cost);
-	schedule_request();
+	int r = super::do_add_request(std::move(request),
+				      client_id,
+				      req_params,
+				      time,
+				      cost);
+        if (r == 0) {
+	  schedule_request();
+        }
 #ifdef PROFILE
 	add_request_timer.stop();
 #endif
+	return r;
       }
 
 

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -359,10 +359,8 @@ namespace crimson {
 	  last_tick = _tick;
 	}
 
-	inline void add_request(const RequestTag& tag,
-				const C&          client_id,
-				RequestRef&&      request) {
-	  requests.emplace_back(ClientReq(tag, client_id, std::move(request)));
+	inline void add_request(const RequestTag& tag, RequestRef&& request) {
+	  requests.emplace_back(tag, client, std::move(request));
 	}
 
 	inline const ClientReq& next_request() const {
@@ -919,7 +917,7 @@ namespace crimson {
 
 	RequestTag tag = initial_tag(TagCalc{}, client, req_params, time, cost);
 
-	client.add_request(tag, client.client, std::move(request));
+	client.add_request(tag, std::move(request));
 	if (1 == client.requests.size()) {
 	  // NB: can the following 4 calls to adjust be changed
 	  // promote? Can adding a request ever demote a client in the

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -89,6 +89,11 @@ namespace crimson {
 				"proportion.*max_tag") <<
 	"we should fail if a client tries to generate a reservation tag "
 	"where reservation and proportion are both 0";
+
+      EXPECT_DEATH_IF_SUPPORTED(Queue(client_info_f, AtLimit::Reject),
+				"Assertion.*Reject.*Delayed") <<
+	"we should fail if a client tries to construct a queue with both "
+        "DelayedTagCalc and AtLimit::Reject";
     }
 
 

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -153,7 +153,7 @@ namespace crimson {
 
       Request req;
       dmc::ReqParams req_params(1, 1);
-      pq.add_request_time(req, client, req_params, dmc::get_time());
+      EXPECT_EQ(0, pq.add_request_time(req, client, req_params, dmc::get_time()));
 
       std::this_thread::sleep_for(std::chrono::seconds(1));
 
@@ -311,15 +311,15 @@ namespace crimson {
 
       ReqParams req_params(1,1);
 
-      pq.add_request(MyReq(1), client1, req_params);
-      pq.add_request(MyReq(11), client1, req_params);
-      pq.add_request(MyReq(2), client2, req_params);
-      pq.add_request(MyReq(0), client2, req_params);
-      pq.add_request(MyReq(13), client2, req_params);
-      pq.add_request(MyReq(2), client2, req_params);
-      pq.add_request(MyReq(13), client2, req_params);
-      pq.add_request(MyReq(98), client2, req_params);
-      pq.add_request(MyReq(44), client1, req_params);
+      EXPECT_EQ(0, pq.add_request(MyReq(1), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(11), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(0), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(13), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(13), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(98), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(44), client1, req_params));
 
       EXPECT_EQ(2u, pq.client_count());
       EXPECT_EQ(9u, pq.request_count());
@@ -380,12 +380,12 @@ namespace crimson {
 
       ReqParams req_params(1,1);
 
-      pq.add_request(MyReq(1), client1, req_params);
-      pq.add_request(MyReq(2), client1, req_params);
-      pq.add_request(MyReq(3), client1, req_params);
-      pq.add_request(MyReq(4), client1, req_params);
-      pq.add_request(MyReq(5), client1, req_params);
-      pq.add_request(MyReq(6), client1, req_params);
+      EXPECT_EQ(0, pq.add_request(MyReq(1), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(3), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(4), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(5), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(6), client1, req_params));
 
       EXPECT_EQ(1u, pq.client_count());
       EXPECT_EQ(6u, pq.request_count());
@@ -463,12 +463,12 @@ namespace crimson {
 
       ReqParams req_params(1,1);
 
-      pq.add_request(MyReq(1), client1, req_params);
-      pq.add_request(MyReq(2), client1, req_params);
-      pq.add_request(MyReq(3), client1, req_params);
-      pq.add_request(MyReq(4), client1, req_params);
-      pq.add_request(MyReq(5), client1, req_params);
-      pq.add_request(MyReq(6), client1, req_params);
+      EXPECT_EQ(0, pq.add_request(MyReq(1), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(3), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(4), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(5), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(6), client1, req_params));
 
       EXPECT_EQ(1u, pq.client_count());
       EXPECT_EQ(6u, pq.request_count());
@@ -546,15 +546,15 @@ namespace crimson {
 
       ReqParams req_params(1,1);
 
-      pq.add_request(MyReq(1), client1, req_params);
-      pq.add_request(MyReq(11), client1, req_params);
-      pq.add_request(MyReq(2), client2, req_params);
-      pq.add_request(MyReq(0), client2, req_params);
-      pq.add_request(MyReq(13), client2, req_params);
-      pq.add_request(MyReq(2), client2, req_params);
-      pq.add_request(MyReq(13), client2, req_params);
-      pq.add_request(MyReq(98), client2, req_params);
-      pq.add_request(MyReq(44), client1, req_params);
+      EXPECT_EQ(0, pq.add_request(MyReq(1), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(11), client1, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(0), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(13), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(2), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(13), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(98), client2, req_params));
+      EXPECT_EQ(0, pq.add_request(MyReq(44), client1, req_params));
 
       EXPECT_EQ(2u, pq.client_count());
       EXPECT_EQ(9u, pq.request_count());
@@ -620,8 +620,8 @@ namespace crimson {
       auto now = dmc::get_time();
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request(Request{}, client1, req_params);
-	pq->add_request(Request{}, client2, req_params);
+	EXPECT_EQ(0, pq->add_request(Request{}, client1, req_params));
+	EXPECT_EQ(0, pq->add_request(Request{}, client2, req_params));
 	now += 0.0001;
       }
 
@@ -674,8 +674,8 @@ namespace crimson {
       auto old_time = dmc::get_time() - 100.0;
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request_time(Request{}, client1, req_params, old_time);
-	pq->add_request_time(Request{}, client2, req_params, old_time);
+	EXPECT_EQ(0, pq->add_request_time(Request{}, client1, req_params, old_time));
+	EXPECT_EQ(0, pq->add_request_time(Request{}, client2, req_params, old_time));
 	old_time += 0.001;
       }
 
@@ -730,8 +730,8 @@ namespace crimson {
       auto now = dmc::get_time();
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request(Request{}, client1, req_params);
-	pq->add_request(Request{}, client2, req_params);
+	EXPECT_EQ(0, pq->add_request(Request{}, client1, req_params));
+	EXPECT_EQ(0, pq->add_request(Request{}, client2, req_params));
 	now += 0.0001;
       }
 
@@ -764,8 +764,8 @@ namespace crimson {
       now = dmc::get_time();
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request(Request{}, client1, req_params);
-	pq->add_request(Request{}, client2, req_params);
+	EXPECT_EQ(0, pq->add_request(Request{}, client1, req_params));
+	EXPECT_EQ(0, pq->add_request(Request{}, client2, req_params));
 	now += 0.0001;
       }
 
@@ -827,8 +827,8 @@ namespace crimson {
       auto now = dmc::get_time();
 
       for (int i = 0; i < 5; ++i) {
-	pq->add_request(Request{}, client1, req_params);
-	pq->add_request(Request{}, client2, req_params);
+	EXPECT_EQ(0, pq->add_request(Request{}, client1, req_params));
+	EXPECT_EQ(0, pq->add_request(Request{}, client2, req_params));
 	now += 0.0001;
       }
 
@@ -860,8 +860,8 @@ namespace crimson {
       now = dmc::get_time();
 
       for (int i = 0; i < 6; ++i) {
-	pq->add_request(Request{}, client1, req_params);
-	pq->add_request(Request{}, client2, req_params);
+	EXPECT_EQ(0, pq->add_request(Request{}, client1, req_params));
+	EXPECT_EQ(0, pq->add_request(Request{}, client2, req_params));
 	now += 0.0001;
       }
 
@@ -918,8 +918,8 @@ namespace crimson {
 
       // add six requests; for same client reservations spaced one apart
       for (int i = 0; i < 3; ++i) {
-	pq->add_request_time(Request{}, client1, req_params, start_time);
-	pq->add_request_time(Request{}, client2, req_params, start_time);
+	EXPECT_EQ(0, pq->add_request_time(Request{}, client1, req_params, start_time));
+	EXPECT_EQ(0, pq->add_request_time(Request{}, client2, req_params, start_time));
       }
 
       Queue::PullReq pr = pq->pull_request(start_time + 0.5);
@@ -998,7 +998,7 @@ namespace crimson {
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(Request{}, client1, req_params, now + 100);
+      EXPECT_EQ(0, pq->add_request_time(Request{}, client1, req_params, now + 100));
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::future, pr.type);
@@ -1029,7 +1029,7 @@ namespace crimson {
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(Request{}, client1, req_params, now + 100);
+      EXPECT_EQ(0, pq->add_request_time(Request{}, client1, req_params, now + 100));
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);
@@ -1060,7 +1060,7 @@ namespace crimson {
       // make sure all times are well before now
       auto now = dmc::get_time();
 
-      pq->add_request_time(Request{}, client1, req_params, now + 100);
+      EXPECT_EQ(0, pq->add_request_time(Request{}, client1, req_params, now + 100));
       Queue::PullReq pr = pq->pull_request(now);
 
       EXPECT_EQ(Queue::NextReqType::returning, pr.type);

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -71,7 +71,7 @@ namespace crimson {
 	}
       };
 
-      QueueRef pq(new Queue(client_info_f, false));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Wait));
       ReqParams req_params(1,1);
 
       // Disable coredumps
@@ -116,7 +116,7 @@ namespace crimson {
 	       std::chrono::seconds(3),
 	       std::chrono::seconds(5),
 	       std::chrono::seconds(2),
-	       false);
+	       AtLimit::Wait);
 
       auto lock_pq = [&](std::function<void()> code) {
 	test_locked(pq.data_mtx, code);
@@ -304,7 +304,7 @@ namespace crimson {
 	return &info1;
       };
 
-      Queue pq(client_info_f, true);
+      Queue pq(client_info_f, AtLimit::Allow);
 
       EXPECT_EQ(0u, pq.client_count());
       EXPECT_EQ(0u, pq.request_count());
@@ -373,7 +373,7 @@ namespace crimson {
 	return &info1;
       };
 
-      Queue pq(client_info_f, true);
+      Queue pq(client_info_f, AtLimit::Allow);
 
       EXPECT_EQ(0u, pq.client_count());
       EXPECT_EQ(0u, pq.request_count());
@@ -456,7 +456,7 @@ namespace crimson {
 	return &info1;
       };
 
-      Queue pq(client_info_f, true);
+      Queue pq(client_info_f, AtLimit::Allow);
 
       EXPECT_EQ(0u, pq.client_count());
       EXPECT_EQ(0u, pq.request_count());
@@ -539,7 +539,7 @@ namespace crimson {
 	return &info1;
       };
 
-      Queue pq(client_info_f, true);
+      Queue pq(client_info_f, AtLimit::Allow);
 
       EXPECT_EQ(0u, pq.client_count());
       EXPECT_EQ(0u, pq.request_count());
@@ -613,7 +613,7 @@ namespace crimson {
 	}
       };
 
-      pq = QueueRef(new Queue(client_info_f, false));
+      pq = QueueRef(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(1,1);
 
@@ -666,7 +666,7 @@ namespace crimson {
 	}
       };
 
-      QueueRef pq(new Queue(client_info_f, false));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(1,1);
 
@@ -723,7 +723,7 @@ namespace crimson {
 	}
       };
 
-      pq = QueueRef(new Queue(client_info_f, false));
+      pq = QueueRef(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(1,1);
 
@@ -820,7 +820,7 @@ namespace crimson {
 	}
       };
 
-      pq = QueueRef(new Queue(client_info_f, false));
+      pq = QueueRef(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(1,1);
 
@@ -909,7 +909,7 @@ namespace crimson {
 	}
       };
 
-      QueueRef pq(new Queue(client_info_f, false));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(0, 0);
 
@@ -964,7 +964,7 @@ namespace crimson {
 	return &info;
       };
 
-      QueueRef pq(new Queue(client_info_f, false));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Wait));
 
       // Request req;
       ReqParams req_params(1,1);
@@ -991,7 +991,7 @@ namespace crimson {
 	return &info;
       };
 
-      QueueRef pq(new Queue(client_info_f, false));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Wait));
 
       ReqParams req_params(1,1);
 
@@ -1022,7 +1022,7 @@ namespace crimson {
 	return &info;
       };
 
-      QueueRef pq(new Queue(client_info_f, true));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Allow));
 
       ReqParams req_params(1,1);
 
@@ -1053,7 +1053,7 @@ namespace crimson {
 	return &info;
       };
 
-      QueueRef pq(new Queue(client_info_f, true));
+      QueueRef pq(new Queue(client_info_f, AtLimit::Allow));
 
       ReqParams req_params(1,1);
 


### PR DESCRIPTION
replaces `bool allow_limit_break` with an `enum AtLimit` to enable a third option, whereby calls to `add_request()` will fail with `EAGAIN` if the client is at/above its limit

add a tunable threshold for `AtLimit::Reject` such that requests are only rejected once the limit is over this threshold. this is intended to help balance the queue depth with the desire to enforce an upper bound on the time spent waiting in the queue (and the memory use associated with queued requests)

for example, setting this threshold to 1 second for a client with limit=10 would allow that client to enqueue 10 requests before any are rejected. with a threshold of 0, all but the first would be rejected and require the client to resubmit

to simplify queue construction, a variant type `AtLimitParam` allows construction with either an explicit `AtLimit` enum value, or with a `RejectThreshold` value that implies `AtLimit::Reject`