### PR TITLE
server: delayed tag calculation as a template parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 set(CMAKE_CXX_FLAGS
   "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-write-strings -Wall -pthread")
 
-if(DO_NOT_DELAY_TAG_CALC)
-  add_definitions(-DDO_NOT_DELAY_TAG_CALC)
-endif()
-
 if (NOT(TARGET gtest AND TARGET gtest_main))
   if (NOT GTEST_FOUND)
     find_package(GTest QUIET)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ To turn on profiling, run cmake with an additional:
 
     -DPROFILE=yes
 
-An optimization/fix to the published algorithm has been added and is
-on by default. To disable this optimization/fix run cmake with:
-
-    -DDO_NOT_DELAY_TAG_CALC=yes
-
 ## Running make
 
 ### Building the dmclock library


### PR DESCRIPTION
part of ongoing work in https://github.com/ceph/dmclock/pull/50, where `AtLimit::Reject` is not compatible with delayed tag calculation. posting separately for review

provides two overloads of functions `initial_request_tag()`, `update_next_tag()`, and `reduce_reservation_tags()`, and uses [tag dispatch](https://www.boost.org/community/generic_programming.html#tag_dispatching) to select the desired overload