### PR TITLE
 Added const references to various function parameters

### DIFF
--- a/sim/src/ConfUtils.cc
+++ b/sim/src/ConfUtils.cc
@@ -38,8 +38,8 @@ using std::string;
 
 ////////////////////////////// ConfLine //////////////////////////////
 ConfLine::
-ConfLine(const std::string &key_, const std::string val_,
-      const std::string newsection_, const std::string comment_, int line_no_)
+ConfLine(const std::string &key_, const std::string &val_,
+      const std::string &newsection_, const std::string &comment_, int line_no_)
   : key(key_), val(val_), newsection(newsection_)
 {
   // If you want to implement writable ConfFile support, you'll need to save

--- a/sim/src/ConfUtils.h
+++ b/sim/src/ConfUtils.h
@@ -37,8 +37,8 @@
  */
 class ConfLine {
 public:
-  ConfLine(const std::string &key_, const std::string val_,
-	   const std::string newsection_, const std::string comment_, int line_no_);
+  ConfLine(const std::string &key_, const std::string &val_,
+	   const std::string &newsection_, const std::string &comment_, int line_no_);
   bool operator<(const ConfLine &rhs) const;
   friend std::ostream &operator<<(std::ostream& oss, const ConfLine &l);
 

--- a/sim/src/simulate.h
+++ b/sim/src/simulate.h
@@ -305,7 +305,7 @@ namespace crimson {
 
       template<typename T>
       void display_server_internal_stats(std::ostream& out,
-					 std::string time_unit) {
+					 const std::string& time_unit) {
 	T add_request_time(0);
 	T request_complete_time(0);
 	uint32_t add_request_count = 0;
@@ -351,7 +351,7 @@ namespace crimson {
 
       template<typename T>
       void display_client_internal_stats(std::ostream& out,
-					 std::string time_unit) {
+					 const std::string& time_unit) {
 	T track_resp_time(0);
 	T get_req_params_time(0);
 	uint32_t track_resp_count = 0;

--- a/sim/src/str_list.h
+++ b/sim/src/str_list.h
@@ -93,7 +93,7 @@ extern void get_str_set(const std::string& str,
  * @param [in] sep String used to join each element from **v**
  * @return empty string if **v** is empty or concatenated string
 **/
-inline std::string str_join(const std::vector<std::string>& v, std::string sep)
+inline std::string str_join(const std::vector<std::string>& v, const std::string& sep)
 {
   if (v.empty())
     return std::string();

--- a/support/src/run_every.h
+++ b/support/src/run_every.h
@@ -52,7 +52,7 @@ namespace crimson {
 
     template<typename D>
     RunEvery(D                     _wait_period,
-	     std::function<void()> _body) :
+	     const std::function<void()>& _body) :
       wait_period(duration_cast<milliseconds>(_wait_period)),
       body(_body)
     {


### PR DESCRIPTION
This pull request adds a small enhancement by avoiding copying data when unnecessary and mitigates the following cppcheck messages:

```
[sim/src/ConfUtils.cc:41]: (performance) Function parameter 'val_' should be passed by reference.
[sim/src/ConfUtils.cc:42]: (performance) Function parameter 'newsection_' should be passed by reference.
[sim/src/ConfUtils.cc:42]: (performance) Function parameter 'comment_' should be passed by reference.
[sim/src/ConfUtils.h:40]: (performance) Function parameter 'val_' should be passed by reference.
[sim/src/ConfUtils.h:41]: (performance) Function parameter 'newsection_' should be passed by reference.
[sim/src/ConfUtils.h:41]: (performance) Function parameter 'comment_' should be passed by reference.
[sim/src/str_list.h:96]: (performance) Function parameter 'sep' should be passed by reference.
[sim/src/simulate.h:308]: (performance) Function parameter 'time_unit' should be passed by reference.
[sim/src/simulate.h:354]: (performance) Function parameter 'time_unit' should be passed by reference.
[support/src/run_every.h:55]: (performance) Function parameter '_body' should be passed by reference.
```