### PR TITLE
misc: mark constructors as explicit

### DIFF
--- a/sim/src/sim_recs.h
+++ b/sim/src/sim_recs.h
@@ -105,7 +105,7 @@ namespace crimson {
     struct TestResponse {
       uint32_t epoch;
 
-      TestResponse(uint32_t _epoch) :
+      explicit TestResponse(uint32_t _epoch) :
 	epoch(_epoch)
       {
 	// empty

--- a/support/test/test_ind_intru_heap.cc
+++ b/support/test/test_ind_intru_heap.cc
@@ -32,7 +32,7 @@ public:
 
     crimson::IndIntruHeapData heap_data;
 
-    Test1(int _data) : data(_data) {}
+    explicit Test1(int _data) : data(_data) {}
 
     friend std::ostream& operator<<(std::ostream& out, const Test1& d) {
         out << d.data << " (" << d.heap_data << ")";

--- a/support/test/test_indirect_intrusive_heap.cc
+++ b/support/test/test_indirect_intrusive_heap.cc
@@ -28,7 +28,7 @@ struct Elem {
   crimson::IndIntruHeapData heap_data;
   crimson::IndIntruHeapData heap_data_alt;
 
-  Elem(int _data) : data(_data) { }
+  explicit Elem(int _data) : data(_data) { }
 
   bool operator==(const Elem& other) {
     return data == other.data;

--- a/support/test/test_intrusive_heap.cc
+++ b/support/test/test_intrusive_heap.cc
@@ -31,7 +31,7 @@ class Test1 {
     crimson::IntruHeapData heap_data;
 
 public:
-    Test1(int _data) : data(_data) {}
+    explicit Test1(int _data) : data(_data) {}
 
     friend std::ostream& operator<<(std::ostream& out, const Test1& d) {
         out << d.data << " (" << d.heap_data << ")";


### PR DESCRIPTION
Set 4 constructors as explicit to avoid implicit usage.

Fix for cppcheck warning:
 Class has a constructor with 1 argument that is
 not explicit. Such constructors should in general be explicit for
 type safety reasons. Using the explicit keyword in the constructor
 means some mistakes when using the class can be avoided.

 For more information check:
  https://www.codeproject.com/Articles/28663/Explicit-Constructor-in-C

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>