### PR TITLE
Set of functionality additions and small adjustments.

### DIFF
--- a/support/src/indirect_intrusive_heap.h
+++ b/support/src/indirect_intrusive_heap.h
@@ -227,6 +227,8 @@ namespace crimson {
 
     bool empty() const { return 0 == count; }
 
+    void clear() { data.clear(); count = 0; }
+
     size_t size() const { return (size_t) count; }
 
     T& top() { return *data[0]; }

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <list>
 #include <vector>
+#include <atomic>
 
 
 #include "dmclock_server.h"
@@ -102,6 +103,7 @@ namespace crimson {
       using Queue = dmc::PushPriorityQueue<ClientId,Request>;
       int client = 17;
       double reservation = 100.0;
+      std::atomic<std::uint32_t> idle_erase_counter(0u);
 
       dmc::ClientInfo ci(reservation, 1.0, 0.0);
       auto client_info_f = [&] (ClientId c) -> const dmc::ClientInfo* {
@@ -114,6 +116,9 @@ namespace crimson {
 			      uint64_t req_cost) {
 	// empty; do nothing
       };
+      auto idle_erase_listener_f = [&idle_erase_counter](const ClientId& c) {
+	idle_erase_counter++;
+      };
 
       Queue pq(client_info_f,
 	       server_ready_f,
@@ -121,7 +126,9 @@ namespace crimson {
 	       std::chrono::seconds(3),
 	       std::chrono::seconds(5),
 	       std::chrono::seconds(2),
-	       AtLimit::Wait);
+	       AtLimit::Wait,
+	       0.0,
+	       idle_erase_listener_f);
 
       auto lock_pq = [&](std::function<void()> code) {
 	test_locked(pq.data_mtx, code);
@@ -176,12 +183,19 @@ namespace crimson {
 	    "after idle age client map entry shows idle.";
 	});
 
+      EXPECT_EQ(0u, idle_erase_counter) <<
+	"idle erase counter is still 0 since client has not yet been "
+	"idle-erased";
+
       std::this_thread::sleep_for(std::chrono::seconds(2));
 
       lock_pq([&] () {
 	  EXPECT_EQ(0u, pq.client_map.size()) <<
 	    "client map loses its entry after erase age";
 	});
+
+      EXPECT_EQ(1u, idle_erase_counter) <<
+	"idle erase counter is now 1 since client has been idle-erased";
     } // TEST
 
 


### PR DESCRIPTION
This commit contains a bunch of minor changes.

First it allows a ClientProfile to be updated with new reservation,
weight, and limit values by adding an update function.

Second it adds an ability to invoke callbacks when a ClientInfo object
is removed due to the idle timeout. Testing this functionality has
been added to the unit tests.

Third we add the ability to clear a heap to help with a more
controlled tear-down.

Finally, dmclock-servers "cleaning" has been renamed "idle erase" to
better indicate the role. Types and variable names have been adjusted
accordingly.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>