### PR TITLE
server: fix wrong calculation to reduce reservation tags

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1218,7 +1218,7 @@ namespace crimson {
     }; // class PriorityQueueBase
 
 
-    template<typename C, typename R, bool IsDelayed=true, bool U1=false, uint B=2>
+    template<typename C, typename R, bool IsDelayed=false, bool U1=false, uint B=2>
     class PullPriorityQueue : public PriorityQueueBase<C,R,IsDelayed,U1,B> {
       using super = PriorityQueueBase<C,R,IsDelayed,U1,B>;
 
@@ -1443,7 +1443,7 @@ namespace crimson {
 
 
     // PUSH version
-    template<typename C, typename R, bool IsDelayed=true, bool U1=false, uint B=2>
+    template<typename C, typename R, bool IsDelayed=false, bool U1=false, uint B=2>
     class PushPriorityQueue : public PriorityQueueBase<C,R,IsDelayed,U1,B> {
 
     protected:

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -129,17 +129,21 @@ namespace crimson {
       double   reservation;
       double   proportion;
       double   limit;
+      uint32_t delta;
+      uint32_t rho;
       Cost     cost;
       bool     ready; // true when within limit
       Time     arrival;
 
       RequestTag(const RequestTag& prev_tag,
 		 const ClientInfo& client,
-		 const uint32_t delta,
-		 const uint32_t rho,
+		 const uint32_t _delta,
+		 const uint32_t _rho,
 		 const Time time,
 		 const Cost _cost = 1u,
 		 const double anticipation_timeout = 0.0) :
+	delta(_delta),
+	rho(_rho),
 	cost(_cost),
 	ready(false),
 	arrival(time)
@@ -183,10 +187,14 @@ namespace crimson {
 
       RequestTag(const double _res, const double _prop, const double _lim,
 		 const Time _arrival,
+		 const uint32_t _delta = 0,
+		 const uint32_t _rho = 0,
 		 const Cost _cost = 1u) :
 	reservation(_res),
 	proportion(_prop),
 	limit(_lim),
+	delta(_delta),
+	rho(_rho),
 	cost(_cost),
 	ready(false),
 	arrival(_arrival)
@@ -199,6 +207,8 @@ namespace crimson {
 	reservation(other.reservation),
 	proportion(other.proportion),
 	limit(other.limit),
+	delta(other.delta),
+	rho(other.rho),
 	cost(other.cost),
 	ready(other.ready),
 	arrival(other.arrival)

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -50,7 +50,7 @@ namespace crimson {
 
     TEST(dmclock_server, bad_tag_deathtest) {
       using ClientId = int;
-      using Queue = dmc::PullPriorityQueue<ClientId,Request>;
+      using Queue = dmc::PullPriorityQueue<ClientId,Request,true>;
       using QueueRef = std::unique_ptr<Queue>;
 
       ClientId client1 = 17;


### PR DESCRIPTION
take the following configuration into account, we found something interesting:
```
[global]
server_groups = 1
client_groups = 1
server_random_selection = 1
server_soft_limit = 0
anticipation_timeout = 0.000

[client.0]
client_count = 1
client_wait = 0
client_total_ops = 10000          // for longer test
client_server_select_range = 10
client_iops_goal = 2000
client_outstanding_ops = 500      // make request queued
client_reservation = 50.0         // with reservation 
client_limit = 100.0
client_weight = 10.0
client_req_cost = 1

[server.0]
server_count = 10
server_iops = 50
server_threads = 1
```
1) At **ImmediateTagCalc** mode,  if we set no small reservation and large outstanding ops for a client to make request queued long in server, we got the IOPS leap high and then fall down regularly as below:
![before-imm](https://user-images.githubusercontent.com/17548747/43713884-c0448e22-99ad-11e8-8ea0-3c9b373c874c.png)
[result-before-imm.txt](https://github.com/ceph/dmclock/files/2262312/before-imm.txt)
We use hard limit, and the limit is 100, but it's highly break limit.  **Is this caused by calculating tags too early ?**

2) then we use the **DelayedTagCalc** mode., we found the curve is pretty smooth, but it still break limit all the time( means over-service):
![before-delay](https://user-images.githubusercontent.com/17548747/43715773-3d41e9be-99b4-11e8-8f8e-356f9af7b8a7.png)
[result-before-delay.txt](https://github.com/ceph/dmclock/files/2262445/before-delay.txt)
we analyzed this situation and found that this over-service issue is caused by using unmatched rho and delta. In DelayedTagCalc mode, we use the current rho and delta from the latest request, but it's not the original intention in dmclock. for example, if client send requests with delta's sequence: 5, 5, 10, 5, 5, 5, 5, 5...   the request with delta 10 means that it should be handled by server at `pre_tag+10*increment` time, while using latest request delta 5, request would be handled at `pre_tag+5*increment` , it was handled in advance.  the delta 10 is probably unused and lost which lead to over-service.

3) Finally, we found out that this  IOPS leap high and fall down problem is caused by wrong calculation to reduce reservation tag after request be handled in weight-based phase. after apply this change, we got the following result:
![after-imm](https://user-images.githubusercontent.com/17548747/43717900-95f28efe-99bb-11e8-8e96-6b8c187718b9.png)
[result-after-imm.txt](https://github.com/ceph/dmclock/files/2262608/after-imm.txt)





