### PR TITLE
sim: fix server_soft_limit can't work properly

### DIFF
--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -193,7 +193,7 @@ int main(int argc, char* argv[]) {
     return new test::DmcQueue(client_info_f,
 			      can_f,
 			      handle_f,
-			      server_soft_limit,
+			      server_soft_limit ? dmc::AtLimit::Allow : dmc::AtLimit::Wait,
 			      anticipation_timeout);
   };
 


### PR DESCRIPTION
server_soft_limit from test configuration file is bool type, it should change as the AtLimit has been introduced. Otherwise the sim test can't work.

Signed-off-by: yanjun <yan.jun8@zte.com.cn>