### PR TITLE
cmake: tell if we are included as subproject or not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,18 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(src)
-add_subdirectory(sim)
 
-enable_testing()
-add_subdirectory(test)
-add_subdirectory(support/test)
-add_test(NAME dmclock-tests
-  COMMAND $<TARGET_FILE:dmclock-tests>)
-add_test(NAME dmclock-data-struct-tests
-  COMMAND $<TARGET_FILE:dmclock-data-struct-tests>)
+# Determine if dmclock is built as a subproject (using add_subdirectory)
+# or if it is the master project.
+set(MASTER_PROJECT FALSE)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MASTER_PROJECT TRUE)
+endif()
+
+option(dmclock_TEST "Generate test targets" ${MASTER_PROJECT})
+if(dmclock_TEST)
+  enable_testing()
+  add_subdirectory(test)
+  add_subdirectory(support/test)
+  add_subdirectory(sim)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(dmclock-tests LINK_PRIVATE
   Threads::Threads
   GTest::GTest
   GTest::Main)
+
+add_test(NAME dmclock-tests
+  COMMAND $<TARGET_FILE:dmclock-tests>)
+add_test(NAME dmclock-data-struct-tests
+  COMMAND $<TARGET_FILE:dmclock-data-struct-tests>)


### PR DESCRIPTION
so the super-project can included dmclock's root directory. as the
"dmclock" target's target_include_directory() uses "$PROJECT_SOURCE_DIR"

Signed-off-by: Kefu Chai <tchaikov@gmail.com>