### PR TITLE
server: fix request blocked caused by do_clean

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -65,6 +65,11 @@ namespace crimson {
       std::numeric_limits<double>::lowest();
     constexpr uint tag_modulo = 1000000;
 
+    constexpr auto standard_idle_age  = std::chrono::seconds(300);
+    constexpr auto standard_erase_age = std::chrono::seconds(600);
+    constexpr auto standard_check_time = std::chrono::seconds(60);
+    constexpr auto aggressive_check_time = std::chrono::seconds(5);
+
     enum class AtLimit {
       // requests are delayed until the limit is restored
       Wait,
@@ -1303,9 +1308,9 @@ namespace crimson {
 			AtLimitParam at_limit_param = AtLimit::Wait,
 			double _anticipation_timeout = 0.0) :
 	PullPriorityQueue(_client_info_f,
-			  std::chrono::minutes(10),
-			  std::chrono::minutes(15),
-			  std::chrono::minutes(6),
+			  standard_idle_age,
+			  standard_erase_age,
+			  standard_check_time,
 			  at_limit_param,
 			  _anticipation_timeout)
       {
@@ -1542,9 +1547,9 @@ namespace crimson {
 	PushPriorityQueue(_client_info_f,
 			  _can_handle_f,
 			  _handle_f,
-			  std::chrono::minutes(10),
-			  std::chrono::minutes(15),
-			  std::chrono::minutes(6),
+			  standard_idle_age,
+			  standard_erase_age,
+			  standard_check_time,
 			  at_limit_param,
 			  _anticipation_timeout)
       {

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -69,6 +69,7 @@ namespace crimson {
     constexpr auto standard_erase_age = std::chrono::seconds(600);
     constexpr auto standard_check_time = std::chrono::seconds(60);
     constexpr auto aggressive_check_time = std::chrono::seconds(5);
+    constexpr uint standard_erase_max = 100;
 
     enum class AtLimit {
       // requests are delayed until the limit is restored
@@ -811,6 +812,10 @@ namespace crimson {
       Duration                  erase_age;
       Duration                  check_time;
       std::deque<MarkPoint>     clean_mark_points;
+      // max number of clients to erase at a time
+      Counter erase_max;
+      // unfinished last erase point
+      Counter last_erase_point = 0;
 
       // NB: All threads declared at end, so they're destructed first!
 
@@ -840,7 +845,8 @@ namespace crimson {
 	finishing(false),
 	idle_age(std::chrono::duration_cast<Duration>(_idle_age)),
 	erase_age(std::chrono::duration_cast<Duration>(_erase_age)),
-	check_time(std::chrono::duration_cast<Duration>(_check_time))
+	check_time(std::chrono::duration_cast<Duration>(_check_time)),
+	erase_max(standard_erase_max)
       {
 	assert(_erase_age >= _idle_age);
 	assert(_check_time < _idle_age);
@@ -1201,10 +1207,11 @@ namespace crimson {
 
 	// first erase the super-old client records
 
-	Counter erase_point = 0;
+	Counter erase_point = last_erase_point;
 	auto point = clean_mark_points.front();
 	while (point.first <= now - erase_age) {
-	  erase_point = point.second;
+	  last_erase_point = point.second;
+	  erase_point = last_erase_point;
 	  clean_mark_points.pop_front();
 	  point = clean_mark_points.front();
 	}
@@ -1218,16 +1225,24 @@ namespace crimson {
 	  }
 	}
 
+	Counter erase_num = 0;
 	if (erase_point > 0 || idle_point > 0) {
 	  for (auto i = client_map.begin(); i != client_map.end(); /* empty */) {
 	    auto i2 = i++;
-	    if (erase_point && i2->second->last_tick <= erase_point) {
+	    if (erase_point && erase_num < erase_max &&
+	        i2->second->last_tick <= erase_point) {
 	      delete_from_heaps(i2->second);
 	      client_map.erase(i2);
+	      erase_num++;
 	    } else if (idle_point && i2->second->last_tick <= idle_point) {
 	      i2->second->idle = true;
 	    }
 	  } // for
+
+	  if (erase_num < erase_max) {
+	      // clean finished, refresh
+	      last_erase_point = 0;
+	  }
 	} // if
       } // do_clean
 

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1225,24 +1225,29 @@ namespace crimson {
 	  }
 	}
 
-	Counter erase_num = 0;
+	Counter erased_num = 0;
 	if (erase_point > 0 || idle_point > 0) {
 	  for (auto i = client_map.begin(); i != client_map.end(); /* empty */) {
 	    auto i2 = i++;
-	    if (erase_point && erase_num < erase_max &&
+	    if (erase_point &&
+	        erased_num < erase_max &&
 	        i2->second->last_tick <= erase_point) {
 	      delete_from_heaps(i2->second);
 	      client_map.erase(i2);
-	      erase_num++;
+	      erased_num++;
 	    } else if (idle_point && i2->second->last_tick <= idle_point) {
 	      i2->second->idle = true;
 	    }
 	  } // for
 
-	  if (erase_num < erase_max) {
-	      // clean finished, refresh
-	      last_erase_point = 0;
+	  auto wperiod = check_time;
+	  if (erased_num >= erase_max) {
+	    wperiod = duration_cast<milliseconds>(aggressive_check_time);
+	  } else {
+	    // clean finished, refresh
+	    last_erase_point = 0;
 	  }
+	  cleaning_job->try_update(wperiod);
 	} // if
       } // do_clean
 

--- a/support/src/run_every.cc
+++ b/support/src/run_every.cc
@@ -73,6 +73,12 @@ void crimson::RunEvery::join() {
   thd.join();
 }
 
+// mtx must be held by caller
+void crimson::RunEvery::try_update(milliseconds _wait_period) {
+  if (_wait_period != wait_period) {
+    wait_period = _wait_period;
+  }
+}
 
 void crimson::RunEvery::run() {
   Lock l(mtx);

--- a/support/src/run_every.h
+++ b/support/src/run_every.h
@@ -71,6 +71,8 @@ namespace crimson {
     ~RunEvery();
 
     void join();
+    // update wait period in milliseconds
+    void try_update(milliseconds _wait_period);
 
   protected:
 

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -100,7 +100,7 @@ namespace crimson {
     TEST(dmclock_server, client_idle_erase) {
       using ClientId = int;
       using Queue = dmc::PushPriorityQueue<ClientId,Request>;
-      int client = 17;
+      ClientId client = 17;
       double reservation = 100.0;
 
       dmc::ClientInfo ci(reservation, 1.0, 0.0);


### PR DESCRIPTION
If there are a large number of clients become old enough to erase in a short time, request may be blocked for a long time. since `do_clean` hold the `data_mtx` lock, other functions `pull_request` or `empty`  have to  wait.

Actually, in one of our testcase of ceph, it switch the `osd_op_queue` to `mclock_client`,  then we create 75, 000 rbd images in a short time, which brings huge clients. it result in OSD be marked down.
```
2018-12-20 20:16:17.266463 7f8bf21b8700  1 heartbeat_map is_healthy 'OSD::osd_op_tp thread 0x7f8bc310c700' had timed out after 60
2018-12-20 20:16:17.691459 7f8bcd921700  0 log_channel(cluster) log [WRN] : Monitor daemon marked osd.15 down, but it is still running
2018-12-20 20:16:17.691491 7f8bcd921700  0 log_channel(cluster) log [DBG] : map e638 wrongly marked me down at e638
```
the root cause is `do_clean()` hold the lock for more than a few minutes,  `OSD::osd_op_tp thread` has been blocked at [#L10464](https://github.com/ceph/ceph/blob/luminous/src/osd/OSD.cc#L10464).

This change try to improve `do_clean` in three ways:
- limit number of old clients to erase at a time.
- adjust check time to do clean more frequent.
- shorten idle/erase age to keep less clients.

However,  I have no idea of why the origin values of `check_time/idle_age/erase_age` at [#L1306](https://github.com/ceph/dmclock/blob/master/src/dmclock_server.h#L1306), so I'm not very sure is this adjustment reasonable.

@ivancich it might bother you, could you take a look at this when you back from festivals.
Wish you a happy Christmas holiday.

Signed-off-by: yanjun <yan.jun8@zte.com.cn>