### PR TITLE
server,heap: severely enhance performance for delete_from_heaps

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1256,7 +1256,7 @@ namespace crimson {
       template<IndIntruHeapData ClientRec::*C1,typename C2>
       void delete_from_heap(ClientRecRef& client,
 			    c::IndIntruHeap<ClientRecRef,ClientRec,C1,C2,B>& heap) {
-	auto i = heap.rfind(client);
+	auto i = heap.at(client);
 	heap.remove(i);
       }
 

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -69,7 +69,7 @@ namespace crimson {
     constexpr auto standard_erase_age = std::chrono::seconds(600);
     constexpr auto standard_check_time = std::chrono::seconds(60);
     constexpr auto aggressive_check_time = std::chrono::seconds(5);
-    constexpr uint standard_erase_max = 100;
+    constexpr uint standard_erase_max = 2000;
 
     enum class AtLimit {
       // requests are delayed until the limit is restored

--- a/support/src/indirect_intrusive_heap.h
+++ b/support/src/indirect_intrusive_heap.h
@@ -68,11 +68,11 @@ namespace crimson {
     class Iterator {
       friend IndIntruHeap<I, T, heap_info, C, K>;
 
-      IndIntruHeap<I, T, heap_info, C, K>& heap;
+      IndIntruHeap<I, T, heap_info, C, K>* heap;
       HeapIndex                            index;
 
       Iterator(IndIntruHeap<I, T, heap_info, C, K>& _heap, HeapIndex _index) :
-	heap(_heap),
+	heap(&_heap),
 	index(_index)
       {
 	// empty
@@ -106,14 +106,14 @@ namespace crimson {
       }
 
       Iterator& operator++() {
-	if (index <= heap.count) {
+	if (index <= heap->count) {
 	  ++index;
 	}
 	return *this;
       }
 
       bool operator==(const Iterator& other) const {
-	return &heap == &other.heap && index == other.index;
+	return heap == other.heap && index == other.index;
       }
 
       bool operator!=(const Iterator& other) const {
@@ -121,11 +121,11 @@ namespace crimson {
       }
 
       T& operator*() {
-	return *heap.data[index];
+	return *heap->data[index];
       }
 
       T* operator->() {
-	return &(*heap.data[index]);
+	return &(*heap->data[index]);
       }
 
 #if 0
@@ -140,12 +140,12 @@ namespace crimson {
     class ConstIterator {
       friend IndIntruHeap<I, T, heap_info, C, K>;
 
-      const IndIntruHeap<I, T, heap_info, C, K>& heap;
+      const IndIntruHeap<I, T, heap_info, C, K>* heap;
       HeapIndex                                  index;
 
       ConstIterator(const IndIntruHeap<I, T, heap_info, C, K>& _heap,
 		    HeapIndex _index) :
-	heap(_heap),
+	heap(&_heap),
 	index(_index)
       {
 	// empty
@@ -179,14 +179,14 @@ namespace crimson {
       }
 
       ConstIterator& operator++() {
-	if (index <= heap.count) {
+	if (index <= heap->count) {
 	  ++index;
 	}
 	return *this;
       }
 
       bool operator==(const ConstIterator& other) const {
-	return &heap == &other.heap && index == other.index;
+	return heap == other.heap && index == other.index;
       }
 
       bool operator!=(const ConstIterator& other) const {
@@ -194,11 +194,11 @@ namespace crimson {
       }
 
       const T& operator*() {
-	return *heap.data[index];
+	return *heap->data[index];
       }
 
       const T* operator->() {
-	return &(*heap.data[index]);
+	return &(*heap->data[index]);
       }
     }; // class ConstIterator
 

--- a/support/src/indirect_intrusive_heap.h
+++ b/support/src/indirect_intrusive_heap.h
@@ -344,6 +344,16 @@ namespace crimson {
       return cend();
     }
 
+    Iterator at(const I& ind_item) {
+      auto ind = intru_data_of(ind_item);
+      if (ind >= count) {
+        throw std::out_of_range(
+          std::to_string(ind) + " >= " + std::to_string(count));
+      }
+      assert(data[ind] == ind_item);
+      return Iterator(*this, ind);
+    }
+
     void promote(T& item) {
       sift_up(item.*heap_info);
     }
@@ -416,7 +426,7 @@ namespace crimson {
 
   protected:
 
-    static IndIntruHeapData& intru_data_of(I& item) {
+    static IndIntruHeapData& intru_data_of(const I& item) {
       return (*item).*heap_info;
     }
 


### PR DESCRIPTION
As we discussed in https://github.com/ceph/dmclock/pull/67, **do_clean** might take minutes to erase the old clients if there are thousands of clients became old enough to erase, which result in some unanticipated situation such as request been blocked. so I pushed that PR(https://github.com/ceph/dmclock/pull/67) to limit number of old clients to be erased at a time, it can largely ameliorate this problem. However, it doesn't look perfect since it didn't reduce the time to erase one old client.

Recently , I dig into the code further more and find the time is mainly consumed by **delete_from_heaps** at [#L258](https://github.com/ceph/dmclock/blob/master/support/src/indirect_intrusive_heap.h#L258), and finally [#L223](https://github.com/ceph/dmclock/blob/master/support/src/indirect_intrusive_heap.h#L223).

This change include three ways:

-  use **pointer heap** to enhance performance for Iterator
-  add and use a new method **at** for class IndIntruHeap 
-  increase standard_erase_max as delete_from_heaps become more efficient 

We add some testing code to test the time consumed by **delete_from_heaps**  to erase 100 old clients at a time, the result is show as below:
1. **origin** without this change:
```
### delete_from_heaps consume time: 0.840726s, erased: 100, client_map: 12899
### delete_from_heaps consume time: 1.39886s, erased: 100, client_map: 20499
### delete_from_heaps consume time: 1.84538s, erased: 100, client_map: 31899
### delete_from_heaps consume time: 2.84816s, erased: 100, client_map: 40899
### delete_from_heaps consume time: 3.25994s, erased: 100, client_map: 50699
### delete_from_heaps consume time: 3.62733s, erased: 100, client_map: 60599
### delete_from_heaps consume time: 5.427s, erased: 100, client_map: 70099
### delete_from_heaps consume time: 5.46223s, erased: 100, client_map: 70400
```

2. with this **pointer heap** change:
```
### delete_from_heaps consume time: 0.0147157s, erased: 100, client_map: 12899
### delete_from_heaps consume time: 0.0150367s, erased: 100, client_map: 21399
### delete_from_heaps consume time: 0.0374631s, erased: 100, client_map: 31199
### delete_from_heaps consume time: 0.0375769s, erased: 100, client_map: 40999
### delete_from_heaps consume time: 0.0368521s, erased: 100, client_map: 50799
### delete_from_heaps consume time: 0.0645182s, erased: 100, client_map: 60199
```

3. with this **pointer heap** and **at** changes:
```
### delete_from_heaps consume time: 0.00179381s, erased: 100, client_map: 12399
### delete_from_heaps consume time: 0.00249408s, erased: 100, client_map: 20399
### delete_from_heaps consume time: 0.00224836s, erased: 100, client_map: 30073
### delete_from_heaps consume time: 0.00234324s, erased: 100, client_map: 40599
### delete_from_heaps consume time: 0.00492391s, erased: 100, client_map: 50099
### delete_from_heaps consume time: 0.00838497s, erased: 100, client_map: 60399
### delete_from_heaps consume time: 0.00867261s, erased: 100, client_map: 61033
```
Signed-off-by: yanjun <yan.jun8@zte.com.cn>