### PR TITLE
sim.src,support,test: replace uint with unsigned/size_t

### DIFF
--- a/sim/src/config.cc
+++ b/sim/src/config.cc
@@ -142,7 +142,7 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
   if (!cf.read("global", "anticipation_timeout", val))
     g_conf.anticipation_timeout = stod(val);
 
-  for (uint i = 0; i < g_conf.server_groups; i++) {
+  for (unsigned i = 0; i < g_conf.server_groups; i++) {
     srv_group_t st;
     std::string section = "server." + std::to_string(i);
     if (!cf.read(section, "server_count", val))
@@ -154,7 +154,7 @@ int crimson::qos_simulation::parse_config_file(const std::string &fname, sim_con
     g_conf.srv_group.push_back(st);
   }
 
-  for (uint i = 0; i < g_conf.client_groups; i++) {
+  for (unsigned i = 0; i < g_conf.client_groups; i++) {
     cli_group_t ct;
     std::string section = "client." + std::to_string(i);
     if (!cf.read(section, "client_count", val))

--- a/sim/src/config.h
+++ b/sim/src/config.h
@@ -30,23 +30,23 @@ namespace crimson {
   namespace qos_simulation {
 
     struct cli_group_t {
-      uint client_count;
+      unsigned client_count;
       std::chrono::seconds client_wait;
-      uint client_total_ops;
-      uint client_server_select_range;
-      uint client_iops_goal;
-      uint client_outstanding_ops;
+      unsigned client_total_ops;
+      unsigned client_server_select_range;
+      unsigned client_iops_goal;
+      unsigned client_outstanding_ops;
       double client_reservation;
       double client_limit;
       double client_weight;
       Cost client_req_cost;
 
-      cli_group_t(uint _client_count = 100,
-		  uint _client_wait = 0,
-		  uint _client_total_ops = 1000,
-		  uint _client_server_select_range = 10,
-		  uint _client_iops_goal = 50,
-		  uint _client_outstanding_ops = 100,
+      cli_group_t(unsigned _client_count = 100,
+		  unsigned _client_wait = 0,
+		  unsigned _client_total_ops = 1000,
+		  unsigned _client_server_select_range = 10,
+		  unsigned _client_iops_goal = 50,
+		  unsigned _client_outstanding_ops = 100,
 		  double _client_reservation = 20.0,
 		  double _client_limit = 60.0,
 		  double _client_weight = 1.0,
@@ -85,13 +85,13 @@ namespace crimson {
 
 
     struct srv_group_t {
-      uint server_count;
-      uint server_iops;
-      uint server_threads;
+      unsigned server_count;
+      unsigned server_iops;
+      unsigned server_threads;
 
-      srv_group_t(uint _server_count = 100,
-		  uint _server_iops = 40,
-		  uint _server_threads = 1) :
+      srv_group_t(unsigned _server_count = 100,
+		  unsigned _server_iops = 40,
+		  unsigned _server_threads = 1) :
 	server_count(_server_count),
 	server_iops(_server_iops),
 	server_threads(_server_threads)
@@ -111,8 +111,8 @@ namespace crimson {
 
 
     struct sim_config_t {
-      uint server_groups;
-      uint client_groups;
+      unsigned server_groups;
+      unsigned client_groups;
       bool server_random_selection;
       bool server_soft_limit;
       double anticipation_timeout;
@@ -120,8 +120,8 @@ namespace crimson {
       std::vector<cli_group_t> cli_group;
       std::vector<srv_group_t> srv_group;
 
-      sim_config_t(uint _server_groups = 1,
-		   uint _client_groups = 1,
+      sim_config_t(unsigned _server_groups = 1,
+		   unsigned _client_groups = 1,
 		   bool _server_random_selection = false,
 		   bool _server_soft_limit = true,
 		   double _anticipation_timeout = 0.0) :

--- a/sim/src/sim_recs.h
+++ b/sim/src/sim_recs.h
@@ -31,8 +31,8 @@
 #include <functional>
 
 
-using ClientId = uint;
-using ServerId = uint;
+using ClientId = unsigned;
+using ServerId = unsigned;
 
 
 namespace crimson {

--- a/sim/src/simulate.h
+++ b/sim/src/simulate.h
@@ -42,8 +42,8 @@ namespace crimson {
       using ClientMap = std::map<ClientId,TC*>;
       using ServerMap = std::map<ServerId,TS*>;
 
-      uint server_count = 0;
-      uint client_count = 0;
+      unsigned server_count = 0;
+      unsigned client_count = 0;
 
       ServerMap servers;
       ClientMap clients;
@@ -106,18 +106,18 @@ namespace crimson {
 	}
       }
 
-      uint get_client_count() const { return client_count; }
-      uint get_server_count() const { return server_count; }
+      unsigned get_client_count() const { return client_count; }
+      unsigned get_server_count() const { return server_count; }
       TC& get_client(ClientId id) { return *clients[id]; }
       TS& get_server(ServerId id) { return *servers[id]; }
-      const ServerId& get_server_id(uint index) const {
+      const ServerId& get_server_id(std::size_t index) const {
 	return server_ids[index];
       }
 
 
-      void add_servers(uint count,
+      void add_servers(unsigned count,
 		       std::function<TS*(ServerId)> create_server_f) {
-	uint i = server_count;
+	unsigned i = server_count;
 
 	// increment server_count before creating servers since they
 	// will start running immediately and may use the server_count
@@ -136,9 +136,9 @@ namespace crimson {
       }
 
 
-      void add_clients(uint count,
+      void add_clients(unsigned count,
 		       std::function<TC*(ClientId)> create_client_f) {
-	uint i = client_count;
+	unsigned i = client_count;
 
 	// increment client_count before creating clients since they
 	// will start running immediately and may use the client_count
@@ -311,7 +311,7 @@ namespace crimson {
 	uint32_t add_request_count = 0;
 	uint32_t request_complete_count = 0;
 
-	for (uint i = 0; i < get_server_count(); ++i) {
+	for (unsigned i = 0; i < get_server_count(); ++i) {
 	  const auto& server = get_server(i);
 	  const auto& is = server.get_internal_stats();
 	  add_request_time +=
@@ -357,7 +357,7 @@ namespace crimson {
 	uint32_t track_resp_count = 0;
 	uint32_t get_req_params_count = 0;
 
-	for (uint i = 0; i < get_client_count(); ++i) {
+	for (unsigned i = 0; i < get_client_count(); ++i) {
 	  const auto& client = get_client(i);
 	  const auto& is = client.get_internal_stats();
 	  track_resp_time +=
@@ -400,7 +400,7 @@ namespace crimson {
 
       const ServerId& server_select_alternate(uint64_t seed,
 					      uint16_t client_idx) {
-	uint index = (client_idx + seed) % server_count;
+	size_t index = (client_idx + seed) % server_count;
 	return server_ids[index];
       }
 
@@ -411,8 +411,8 @@ namespace crimson {
 	return [servers_per,this](uint64_t seed, uint16_t client_idx)
 	  -> const ServerId& {
 	  double factor = double(server_count) / client_count;
-	  uint offset = seed % servers_per;
-	  uint index = (uint(0.5 + client_idx * factor) + offset) % server_count;
+	  size_t offset = seed % servers_per;
+	  size_t index = (size_t(0.5 + client_idx * factor) + offset) % server_count;
 	  return server_ids[index];
 	};
       }
@@ -420,7 +420,7 @@ namespace crimson {
 
       // function to choose a server randomly
       const ServerId& server_select_random(uint64_t seed, uint16_t client_idx) {
-	uint index = prng() % server_count;
+	size_t index = prng() % server_count;
 	return server_ids[index];
       }
 
@@ -431,8 +431,8 @@ namespace crimson {
 	return [servers_per,this](uint64_t seed, uint16_t client_idx)
 	  -> const ServerId& {
 	  double factor = double(server_count) / client_count;
-	  uint offset = prng() % servers_per;
-	  uint index = (uint(0.5 + client_idx * factor) + offset) % server_count;
+	  size_t offset = prng() % servers_per;
+	  size_t index = (size_t(0.5 + client_idx * factor) + offset) % server_count;
 	  return server_ids[index];
 	};
       }

--- a/sim/src/test_dmclock_main.cc
+++ b/sim/src/test_dmclock_main.cc
@@ -77,33 +77,33 @@ int main(int argc, char* argv[]) {
     cli_group.push_back(ct2);
   }
 
-  const uint server_groups = g_conf.server_groups;
-  const uint client_groups = g_conf.client_groups;
+  const unsigned server_groups = g_conf.server_groups;
+  const unsigned client_groups = g_conf.client_groups;
   const bool server_random_selection = g_conf.server_random_selection;
   const bool server_soft_limit = g_conf.server_soft_limit;
   const double anticipation_timeout = g_conf.anticipation_timeout;
-  uint server_total_count = 0;
-  uint client_total_count = 0;
+  unsigned server_total_count = 0;
+  unsigned client_total_count = 0;
 
-  for (uint i = 0; i < client_groups; ++i) {
+  for (unsigned i = 0; i < client_groups; ++i) {
     client_total_count += cli_group[i].client_count;
   }
 
-  for (uint i = 0; i < server_groups; ++i) {
+  for (unsigned i = 0; i < server_groups; ++i) {
     server_total_count += srv_group[i].server_count;
   }
 
   std::vector<test::dmc::ClientInfo> client_info;
-  for (uint i = 0; i < client_groups; ++i) {
+  for (unsigned i = 0; i < client_groups; ++i) {
     client_info.push_back(test::dmc::ClientInfo
 			  { cli_group[i].client_reservation,
 			      cli_group[i].client_weight,
 			      cli_group[i].client_limit } );
   }
 
-  auto ret_client_group_f = [&](const ClientId& c) -> uint {
-    uint group_max = 0;
-    uint i = 0;
+  auto ret_client_group_f = [&](const ClientId& c) -> unsigned {
+    unsigned group_max = 0;
+    unsigned i = 0;
     for (; i < client_groups; ++i) {
       group_max += cli_group[i].client_count;
       if (c < group_max) {
@@ -113,9 +113,9 @@ int main(int argc, char* argv[]) {
     return i;
   };
 
-  auto ret_server_group_f = [&](const ServerId& s) -> uint {
-    uint group_max = 0;
-    uint i = 0;
+  auto ret_server_group_f = [&](const ServerId& s) -> unsigned {
+    unsigned group_max = 0;
+    unsigned i = 0;
     for (; i < server_groups; ++i) {
       group_max += srv_group[i].server_count;
       if (s < group_max) {
@@ -156,7 +156,7 @@ int main(int argc, char* argv[]) {
   };
 
   std::vector<std::vector<sim::CliInst>> cli_inst;
-  for (uint i = 0; i < client_groups; ++i) {
+  for (unsigned i = 0; i < client_groups; ++i) {
     if (cli_group[i].client_wait == std::chrono::seconds(0)) {
       cli_inst.push_back(
 	{ { sim::req_op,
@@ -199,7 +199,7 @@ int main(int argc, char* argv[]) {
 
 
   auto create_server_f = [&](ServerId id) -> test::DmcServer* {
-    uint i = ret_server_group_f(id);
+    unsigned i = ret_server_group_f(id);
     return new test::DmcServer(id,
 			       srv_group[i].server_iops,
 			       srv_group[i].server_threads,
@@ -209,9 +209,9 @@ int main(int argc, char* argv[]) {
   };
 
   auto create_client_f = [&](ClientId id) -> test::DmcClient* {
-    uint i = ret_client_group_f(id);
+    unsigned i = ret_client_group_f(id);
     test::MySim::ClientBasedServerSelectFunc server_select_f;
-    uint client_server_select_range = cli_group[i].client_server_select_range;
+    unsigned client_server_select_range = cli_group[i].client_server_select_range;
     if (!server_random_selection) {
       server_select_f = simulation->make_server_select_alt_range(client_server_select_range);
     } else {
@@ -226,11 +226,11 @@ int main(int argc, char* argv[]) {
 
 #if 1
   std::cout << "[global]" << std::endl << g_conf << std::endl;
-  for (uint i = 0; i < client_groups; ++i) {
+  for (unsigned i = 0; i < client_groups; ++i) {
     std::cout << std::endl << "[client." << i << "]" << std::endl;
     std::cout << cli_group[i] << std::endl;
   }
-  for (uint i = 0; i < server_groups; ++i) {
+  for (unsigned i = 0; i < server_groups; ++i) {
     std::cout << std::endl << "[server." << i << "]" << std::endl;
     std::cout << srv_group[i] << std::endl;
   }
@@ -258,7 +258,7 @@ void test::client_data(std::ostream& out,
 
   int total_r = 0;
   out << std::setw(head_w) << "res_ops:";
-  for (uint i = 0; i < sim->get_client_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_client_count(); ++i) {
     const auto& client = sim->get_client(i);
     auto r = client.get_accumulator().reservation_count;
     total_r += r;
@@ -270,7 +270,7 @@ void test::client_data(std::ostream& out,
 
   int total_p = 0;
   out << std::setw(head_w) << "prop_ops:";
-  for (uint i = 0; i < sim->get_client_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_client_count(); ++i) {
     const auto& client = sim->get_client(i);
     auto p = client.get_accumulator().proportion_count;
     total_p += p;
@@ -288,7 +288,7 @@ void test::server_data(std::ostream& out,
 		       int head_w, int data_w, int data_prec) {
   out << std::setw(head_w) << "res_ops:";
   int total_r = 0;
-  for (uint i = 0; i < sim->get_server_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_server_count(); ++i) {
     const auto& server = sim->get_server(i);
     auto rc = server.get_accumulator().reservation_count;
     total_r += rc;
@@ -300,7 +300,7 @@ void test::server_data(std::ostream& out,
 
   out << std::setw(head_w) << "prop_ops:";
   int total_p = 0;
-  for (uint i = 0; i < sim->get_server_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_server_count(); ++i) {
     const auto& server = sim->get_server(i);
     auto pc = server.get_accumulator().proportion_count;
     total_p += pc;
@@ -318,7 +318,7 @@ void test::server_data(std::ostream& out,
 #ifdef PROFILE
   crimson::ProfileCombiner<std::chrono::nanoseconds> art_combiner;
   crimson::ProfileCombiner<std::chrono::nanoseconds> rct_combiner;
-  for (uint i = 0; i < sim->get_server_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_server_count(); ++i) {
     const auto& q = sim->get_server(i).get_priority_queue();
     const auto& art = q.add_request_timer;
     art_combiner.combine(art);

--- a/sim/src/test_ssched_main.cc
+++ b/sim/src/test_ssched_main.cc
@@ -49,18 +49,18 @@ using Cost = uint32_t;
 int main(int argc, char* argv[]) {
   // server params
 
-  const uint server_count = 100;
-  const uint server_iops = 40;
-  const uint server_threads = 1;
+  const unsigned server_count = 100;
+  const unsigned server_iops = 40;
+  const unsigned server_threads = 1;
 
   // client params
 
-  const uint client_total_ops = 1000;
-  const uint client_count = 100;
-  const uint client_server_select_range = 10;
-  const uint client_wait_count = 1;
-  const uint client_iops_goal = 50;
-  const uint client_outstanding_ops = 100;
+  const unsigned client_total_ops = 1000;
+  const unsigned client_count = 100;
+  const unsigned client_server_select_range = 10;
+  const unsigned client_wait_count = 1;
+  const unsigned client_iops_goal = 50;
+  const unsigned client_outstanding_ops = 100;
   const std::chrono::seconds client_wait(10);
 
   auto client_disp_filter = [=] (const ClientId& i) -> bool {
@@ -162,7 +162,7 @@ void test::server_data(std::ostream& out,
 		       int head_w, int data_w, int data_prec) {
   out << std::setw(head_w) << "requests:";
   int total_req = 0;
-  for (uint i = 0; i < sim->get_server_count(); ++i) {
+  for (unsigned i = 0; i < sim->get_server_count(); ++i) {
     const auto& server = sim->get_server(i);
     auto req_count = server.get_accumulator().request_count;
     total_req += req_count;
@@ -175,7 +175,7 @@ void test::server_data(std::ostream& out,
 #ifdef PROFILE
     crimson::ProfileCombiner<std::chrono::nanoseconds> art_combiner;
     crimson::ProfileCombiner<std::chrono::nanoseconds> rct_combiner;
-    for (uint i = 0; i < sim->get_server_count(); ++i) {
+    for (unsigned i = 0; i < sim->get_server_count(); ++i) {
       const auto& q = sim->get_server(i).get_priority_queue();
       const auto& art = q.add_request_timer;
       art_combiner.combine(art);

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -63,13 +63,13 @@ namespace crimson {
     constexpr double min_tag = std::numeric_limits<double>::is_iec559 ?
       -std::numeric_limits<double>::infinity() :
       std::numeric_limits<double>::lowest();
-    constexpr uint tag_modulo = 1000000;
+    constexpr unsigned tag_modulo = 1000000;
 
     constexpr auto standard_idle_age  = std::chrono::seconds(300);
     constexpr auto standard_erase_age = std::chrono::seconds(600);
     constexpr auto standard_check_time = std::chrono::seconds(60);
     constexpr auto aggressive_check_time = std::chrono::seconds(5);
-    constexpr uint standard_erase_max = 2000;
+    constexpr unsigned standard_erase_max = 2000;
 
     enum class AtLimit {
       // requests are delayed until the limit is restored
@@ -279,7 +279,7 @@ namespace crimson {
     //   recent values of rho and delta.
     // U1 determines whether to use client information function dynamically,
     // B is heap branching factor
-    template<typename C, typename R, bool IsDelayed, bool U1, uint B>
+    template<typename C, typename R, bool IsDelayed, bool U1, unsigned B>
     class PriorityQueueBase {
       // we don't want to include gtest.h just for FRIEND_TEST
       friend class dmclock_server_client_idle_erase_Test;
@@ -622,7 +622,7 @@ namespace crimson {
       }
 
 
-      uint get_heap_branching_factor() const {
+      unsigned get_heap_branching_factor() const {
 	return B;
       }
 
@@ -1273,7 +1273,7 @@ namespace crimson {
     }; // class PriorityQueueBase
 
 
-    template<typename C, typename R, bool IsDelayed=false, bool U1=false, uint B=2>
+    template<typename C, typename R, bool IsDelayed=false, bool U1=false, unsigned B=2>
     class PullPriorityQueue : public PriorityQueueBase<C,R,IsDelayed,U1,B> {
       using super = PriorityQueueBase<C,R,IsDelayed,U1,B>;
 
@@ -1499,7 +1499,7 @@ namespace crimson {
 
 
     // PUSH version
-    template<typename C, typename R, bool IsDelayed=false, bool U1=false, uint B=2>
+    template<typename C, typename R, bool IsDelayed=false, bool U1=false, unsigned B=2>
     class PushPriorityQueue : public PriorityQueueBase<C,R,IsDelayed,U1,B> {
 
     protected:
@@ -1668,7 +1668,7 @@ namespace crimson {
       template<typename C1,
 	       IndIntruHeapData super::ClientRec::*C2,
 	       typename C3,
-	       uint B4>
+	       unsigned B4>
       typename super::RequestMeta
       submit_top_request(IndIntruHeap<C1,typename super::ClientRec,C2,C3,B4>& heap,
 			 PhaseType phase) {

--- a/src/dmclock_util.cc
+++ b/src/dmclock_util.cc
@@ -21,7 +21,7 @@
 #include "dmclock_util.h"
 
 
-std::string crimson::dmclock::format_time(const Time& time, uint modulo) {
+std::string crimson::dmclock::format_time(const Time& time, unsigned modulo) {
   long subtract = long(time / modulo) * modulo;
   std::stringstream ss;
   ss << std::fixed << std::setprecision(4) << (time - subtract);

--- a/src/dmclock_util.h
+++ b/src/dmclock_util.h
@@ -52,7 +52,7 @@ namespace crimson {
 #endif
     }
 
-    std::string format_time(const Time& time, uint modulo = 1000);
+    std::string format_time(const Time& time, unsigned modulo = 1000);
 
     void debugger();
 

--- a/support/test/test_indirect_intrusive_heap.cc
+++ b/support/test/test_indirect_intrusive_heap.cc
@@ -663,7 +663,7 @@ TEST_F(HeapFixture1, shared_data) {
 
 TEST_F(HeapFixture1, iterator_basics) {
   {
-    uint count = 0;
+    unsigned count = 0;
     for(auto i = heap.begin(); i != heap.end(); ++i) {
       ++count;
     }
@@ -708,7 +708,7 @@ TEST_F(HeapFixture1, const_iterator_basics) {
   const auto& cheap = heap;
 
   {
-    uint count = 0;
+    unsigned count = 0;
     for(auto i = cheap.cbegin(); i != cheap.cend(); ++i) {
       ++count;
     }

--- a/test/test_dmclock_server.cc
+++ b/test/test_dmclock_server.cc
@@ -812,7 +812,7 @@ namespace crimson {
       info2.push_back(dmc::ClientInfo(0.0, 200.0, 0.0));
       info2.push_back(dmc::ClientInfo(0.0, 50.0, 0.0));
 
-      uint cli_info_group = 0;
+      size_t cli_info_group = 0;
 
       QueueRef pq;
 


### PR DESCRIPTION
`uint` and friends are only for backward compatibility. they are not
standardized. and is only available in glibc when `_GNU_SOURCE` is defined.
other implementations of libc might or might not define this type.

we should avoid using it. `unsigned` is used to replace `uint`. and
as an alternative, `size_t` is used when `uint` is used as an index of
array, as `std::size_t` is the index's type used by
`std::vector::operator[]`.

see also https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59945

Signed-off-by: Kefu Chai <tchaikov@gmail.com>