### PR TITLE
Make K use a standard type

### DIFF
--- a/support/src/indirect_intrusive_heap.h
+++ b/support/src/indirect_intrusive_heap.h
@@ -48,7 +48,7 @@ namespace crimson {
 	   typename T,
 	   IndIntruHeapData T::*heap_info,
 	   typename C,
-	   uint K = 2>
+	   unsigned K = 2>
   class IndIntruHeap {
 
     // shorthand


### PR DESCRIPTION
uint is undefined on musl as it isnt a standard type.
Replaced uint with the standard type "unsigned int" to resolve compilation issue on musl.