### PR TITLE
~PushPriorityQueue signals sched_ahead_cv under lock

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1580,7 +1580,10 @@ namespace crimson {
 
       ~PushPriorityQueue() {
 	this->finishing = true;
-	sched_ahead_cv.notify_one();
+	{
+	  std::lock_guard<std::mutex> l(sched_ahead_mtx);
+	  sched_ahead_cv.notify_one();
+	}
 	sched_ahead_thd.join();
       }
 


### PR DESCRIPTION
by holding the lock while signaling, we avoid missing that signal in run_sched_ahead() and hanging forever at:
```c++
          if (TimeZero == sched_ahead_when) {
            sched_ahead_cv.wait(l);
```
Fixes: https://tracker.ceph.com/issues/46734