### PR TITLE
cleanups for run_sched_ahead()

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1763,12 +1763,11 @@ namespace crimson {
 	  if (TimeZero == sched_ahead_when) {
 	    sched_ahead_cv.wait(l, pred);
 	  } else {
-	    Time now;
-	    while (!this->finishing && (now = get_time()) < sched_ahead_when) {
-	      long microseconds_l = long(1 + 1000000 * (sched_ahead_when - now));
-	      auto microseconds = std::chrono::microseconds(microseconds_l);
-	      sched_ahead_cv.wait_for(l, microseconds, pred);
-	    }
+	    // cast from Time -> duration<Time> -> Duration -> TimePoint
+	    const auto until = typename super::TimePoint{
+		duration_cast<typename super::Duration>(
+		    std::chrono::duration<Time>{sched_ahead_when})};
+	    sched_ahead_cv.wait_until(l, until, pred);
 	    sched_ahead_when = TimeZero;
 	    if (this->finishing) return;
 

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -296,7 +296,8 @@ namespace crimson {
 
     protected:
 
-      using TimePoint = decltype(std::chrono::steady_clock::now());
+      using Clock = std::chrono::steady_clock;
+      using TimePoint = Clock::time_point;
       using Duration = std::chrono::milliseconds;
       using MarkPoint = std::pair<TimePoint,Counter>;
 


### PR DESCRIPTION
Adds a predicate to some calls to wait, so waits can leave early when shutting down.

Cleans up the code in a few areas.