### PR TITLE
server: fix reduce_reservation_tags function with cost

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1078,7 +1078,7 @@ namespace crimson {
 	  // only maintain a tag for the first request
 	  auto& r = client.requests.front();
 	  r.tag.reservation -=
-	    client.info->reservation_inv * std::max(uint32_t(1), tag.rho);
+	    client.info->reservation_inv * (tag.cost + tag.rho);
 	}
       }
 
@@ -1086,7 +1086,7 @@ namespace crimson {
       void reduce_reservation_tags(ImmediateTagCalc imm, ClientRec& client,
                                    const RequestTag& tag) {
         double res_offset =
-          client.info->reservation_inv * std::max(uint32_t(1), tag.rho);
+          client.info->reservation_inv * (tag.cost + tag.rho);
 	for (auto& r : client.requests) {
 	  r.tag.reservation -= res_offset;
 	}
@@ -1104,7 +1104,7 @@ namespace crimson {
 
 	// don't forget to update previous tag
 	client.prev_tag.reservation -=
-	  client.info->reservation_inv * std::max(uint32_t(1), tag.rho);
+	  client.info->reservation_inv * (tag.cost + tag.rho);
 	resv_heap.promote(client);
       }
 


### PR DESCRIPTION
I have read the [PR58](https://github.com/ceph/dmclock/pull/58) and think there still exist some problems in reduce_reservation_tags function especially when cost is not 1.
take the following configuration.
```
[global]
server_groups = 1
client_groups = 2
server_random_selection = 1
server_soft_limit = 0
anticipation_timeout = 0.000

[client.0]
client_count = 1
client_wait = 0
client_total_ops = 5000       
client_server_select_range = 10
client_iops_goal = 5000
client_outstanding_ops = 10000      // make request queued
client_reservation = 100.0      // with reservation 
client_limit = 100000000.0
client_weight = 100.0
client_req_cost = 5

[client.1]
client_count = 2
client_wait = 4      // make client.0 handled in weight-based phase in the first 4 seconds     
client_total_ops = 40000          
client_server_select_range = 10
client_iops_goal = 40000
client_outstanding_ops = 100000  // occuy OPS    
client_reservation = 1000.0         
client_limit = 100000000.0
client_weight = 1000000.0      
client_req_cost = 1

[server.0]
server_count = 1
server_iops = 5000
server_threads = 1
```
the reservation of client.0 is 100 and its request cost is 5, so its OPS reservation should be 100 / 5 = 20, but the result OPS is less than 20(t_2~t_13).
```
==== Client Data ====
     client:       0       1       2  total
        t_0:  929.00    0.00    0.00  929.00
        t_1:  918.50    0.00    0.00  918.50
        t_2:    4.00 1903.00 1906.50 3813.50
        t_3:    2.50 1604.50 1614.00 3221.00
        t_4:    2.00 1349.50 1351.50 2703.00
        t_5:    2.50 1354.00 1377.00 2733.50
        t_6:    2.50 1387.50 1394.00 2784.00
        t_7:    2.50 1406.50 1425.50 2834.50
        t_8:    3.00 1416.00 1475.00 2894.00
        t_9:    3.00 1433.50 1511.00 2947.50
       t_10:    3.50 1461.50 1563.00 3028.00
       t_11:    3.50 1513.50 1634.50 3151.50
       t_12:    3.50 1569.00 1716.50 3289.00
       t_13:    4.00 1643.00 1808.50 3455.50
       t_14:  125.00 1958.50 1223.00 3306.50
       t_15:  491.00    0.00    0.00  491.00
       t_16:    0.00    0.00    0.00    0.00
```
[before-result.txt](https://github.com/ceph/dmclock/files/5078488/before-result.txt)
this problem is caused by wrong calculation to reduce reservation tag after request be handled in weight-based phase. after apply this change, we got the following result:
```
==== Client Data ====
     client:       0       1       2  total
        t_0:  929.50    0.00    0.00  929.50
        t_1:  918.50    0.00    0.00  918.50
        t_2:   21.00 1864.00 1860.00 3745.00
        t_3:   20.00 1501.50 1523.50 3045.00
        t_4:   20.00 1327.00 1336.00 2683.00
        t_5:   20.00 1333.50 1365.50 2719.00
        t_6:   20.00 1363.00 1376.00 2759.00
        t_7:   20.00 1390.00 1398.50 2808.50
        t_8:   20.00 1401.50 1442.50 2864.00
        t_9:   20.00 1421.00 1485.50 2926.50
       t_10:   20.00 1444.50 1539.00 3003.50
       t_11:   20.00 1517.50 1559.50 3097.00
       t_12:   20.00 1574.50 1625.50 3220.00
       t_13:   20.00 1653.50 1710.50 3384.00
       t_14:   20.00 1796.50 1778.00 3594.50
       t_15:  391.00  412.00    0.00  803.00
       t_16:    0.00    0.00    0.00    0.00
```
[after-result.txt](https://github.com/ceph/dmclock/files/5078489/after-result.txt)
