### PR TITLE
server: fix run_sched_ahead() scheduling issue

### DIFF
--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -1763,7 +1763,9 @@ namespace crimson {
 
 	while (!this->finishing) {
 	  // predicate for cond.wait()
-	  const auto pred = [this] () -> bool { return this->finishing; };
+	  const auto pred = [this] () -> bool {
+	    return this->finishing || sched_ahead_when > TimeZero;
+	  };
 
 	  if (TimeZero == sched_ahead_when) {
 	    sched_ahead_cv.wait(l, pred);


### PR DESCRIPTION
The first issue is that the run_sched_ahead() function is blocked when the push priority queue is employed. It is confirmed that the sched_ahead_cv.wait() isn't signaled if the predicate function returns false with this->finishing variable.  For this reason, sched_ahead_when > TimeZero condition is added pred() function. 

The other is that the further request is not fetched when the schedule_request() executes the submit_request() and  sched_ahead_when is set to TimeZero. It implies that run_sched_ahead thread can't wake up by itself. This commit adds that the schedule_request() is called while requests are ready and sched_ahead_when is equal to TimeZero. A unit test has also been added to check whether 3 requests are dispatched after a few seconds.

Fixes: https://tracker.ceph.com/issues/48123
Fixes: https://tracker.ceph.com/issues/48317
Signed-off-by: Yongseok Oh <yongseok.oh@linecorp.com>