### PR TITLE
util: Fix MinGW compilation error

### DIFF
--- a/src/dmclock_util.cc
+++ b/src/dmclock_util.cc
@@ -30,5 +30,9 @@ std::string crimson::dmclock::format_time(const Time& time, unsigned modulo) {
 
 
 void crimson::dmclock::debugger() {
+#ifndef _WIN32
   raise(SIGCONT);
+#else
+  DebugBreak();
+#endif
 }


### PR DESCRIPTION
MinGW complains:
```
/home/ubuntu/dmclock/src/dmclock_util.cc: In function ‘void crimson::dmclock::debugger()’:
/home/ubuntu/dmclock/src/dmclock_util.cc:33:9: error: ‘SIGCONT’ was not declared in this scope
   raise(SIGCONT);
         ^~~~~~~
/home/ubuntu/dmclock/src/dmclock_util.cc:33:9: note: suggested alternative: ‘SIGINT’
   raise(SIGCONT);
         ^~~~~~~
         SIGINT
```

SIGCONT is not defined on Windows.
Replace the call with `DebugBreak`.

Signed-off-by: Alin Gabriel Serdean <aserdean@cloudbasesolutions.com>