### PR TITLE
Implement dynamic tag info functionality for accurate tag calculation with multiple queues configured per server

### DIFF
--- a/src/dmclock_recs.h
+++ b/src/dmclock_recs.h
@@ -18,6 +18,7 @@
 
 #include <ostream>
 #include <assert.h>
+#include <cstdint>
 
 
 namespace crimson {

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -243,6 +243,11 @@ namespace crimson {
 	}
       }
 
+      bool is_valid() {
+        return (reservation != 0.0 && proportion != 0.0 && limit != 0.0 &&
+                cost != 0 && arrival != TimeZero);
+      }
+
     private:
 
       static double tag_calc(const Time time,

--- a/src/dmclock_server.h
+++ b/src/dmclock_server.h
@@ -280,6 +280,45 @@ namespace crimson {
       }
     }; // class RequestTag
 
+    struct ReqTagInfo {
+      // latest tag for a client - read/write
+      RequestTag last_tag = RequestTag(0.0, 0.0, 0.0, TimeZero);
+      // last tick interval - read only
+      Counter last_tick_interval = 0;
+
+      ReqTagInfo() = default;
+
+      ReqTagInfo(const RequestTag& _tag,
+                 const Counter _tick_interval) :
+        last_tag(_tag),
+        last_tick_interval(_tick_interval)
+      {
+        // empty
+      }
+
+      // called by the server to update its latest tag
+      inline void update_tag(const RequestTag& _tag) {
+        last_tag = RequestTag(_tag);
+      }
+
+      // called by dmClock clients to update the
+      // latest tick interval or in other words the
+      // total number of requests handled by other
+      // queues on this server before the current
+      // request on this queue.
+      inline void update_tick(const Counter _tick) {
+        last_tick_interval = _tick;
+      }
+
+      friend std::ostream& operator<<(std::ostream& out,
+                                      const ReqTagInfo& ti) {
+        out << "{ ReqTagInfo:: last_tag:" << ti.last_tag <<
+               " last_tick_interval:" << ti.last_tick_interval <<
+               " }";
+        return out;
+      }
+    }; // class ReqTagInfo
+
     // C is client identifier type, R is request type,
     // IsDelayed controls whether tag calculation is delayed until the request
     //   reaches the front of its queue. This is an optimization over the


### PR DESCRIPTION
To better understand the fix, the problem with multiple queues configured per server
needs to be understood first. This problem is currently faced by Ceph (or Ceph OSDs)
which are clients of dmClock server. Ceph creates multiple op queues per OSD (a.k.a
OSD op queue shards) and each op queue runs independently with the same server
id (OSD ID). With this configuration, tags are calculated on each queue independently.
Therefore, a client could distribute requests across the multiple mClock queues but
the server cannot meet the clients' QoS settings due to the following problem:

### Problem Description

Consider two queues configured on the same server with
items added in the following sequence:
    
       Enqueue--->|T5|T2|T0|--->Dequeue
                       Queue0
    
       Enqueue--->|T4|T3|T1|--->Dequeue
                       Queue1
    
Consider the request arrival times (_arr_time_) in each queue according
to the number associated with each tag, for example:
    
     - Req0 arrives on queue0 at time t0
     - Req1 arrives on queue1 at time t1
     - Req2 arrives on queue0 at time t2
and so on with the final Req5 arriving on queue0 at time t5

Consider x to be any of the  client info parameters i.e. reservation, weight or limit
    
  |  Tag calcs on Queue0    | Tag calcs on Queue1 |
  | ------------------------------------|---------------------------------|
  | T0 = max((NO_TAG + (1/x)), arr_time)| T1 = max((NO_TAG + (1/x)), arr_time)|
  | T2 = max((T0 + (1/x)), arr_time)    | T3 = max((T1 + (1/x)), arr_time)|
  |  T5 = max((T2 + (1/x)), arr_time)    | T4 = max((T3 + (1/x)), arr_time)|
    
For simplicity, assume reservation and limit is set to 3 IOPS, `AtLimit` is
set to '`Wait`' and all requests arrived within a few milliseconds on
both queues.
    
It's pretty clear that all the 3 requests from both the queues will be
scheduled resulting in 6 IOPS which is not correct.

### Proposed Solution

The fix is better understood by applying the solution to the above problem.
The fix is applicable to both `DelayedTagCalc` and `ImmediateTagCalc`.

**Pre-conditions:**

- Dynamic tag info functionality (bool U2 in the pull constructor) is enabled (`is_dynamic_tag_info_f`).
- The dmClock client maintains a mapping of `clientId` to `ReqTagInfo` for each client.
- The dmClock client registers custom implementations for `reqtag_updt_f` and  `reqtag_info_f`.
    
**Solution:**

The fix involves enabling the dynamic tag info for two operations by the following entities:
1.  _the server_ - to update (using `reqtag_updt_f`) the dmClock client with  latest tag for a `clientId` on a given queue once it's calculated. This  is called after tags are calculated in `initial_tag()` and ` update_next_tag()`.
    
2.  _the dmClock client_ - to calculate and update the tick interval before  adding a request to the mClock queue. For a given queue, the tick interval is the number of request(s) added to other mClock queues  _before_ the current one arriving on itself. The latest tick interval  is  read by the server using `reqtag_info_f` before calculating the ` initial_tag()`. See `calc_interval_tag()` on how the new tag is  calculated and see the unit tests on how the client calculates the  tick interval before adding the request to the queue. It's important to note that for `DelayedTagCalc`, the tag will be calculated as part of `initial_tag()` ONLY for non-zero tick intervals.
    
The tag calculation for each tag is shown below with the fix in place:
_(Apologies for the table formatting. Please consider the tag calculation row as the start of a row)_    
|Tag calcs on Queue0                 | Tag calcs on Queue1                      |
|------------------------------------|------------------------------------------|
|**T0 = max((NO_TAG + (1/x)), arr_time)**| **T1 = max((T0 + (i/x)), arr_time)**         |
|tick interval i = 0;                | tick interval i = 1 because req1         |
|                                    | arrived after req0 on Queue0.            |
|                                    | [Note: If tick_inteval > 0, the tag      |
|                                    |  is calculated as part of                |
|                                    |  initial_tag() for DelayedTagCalc]       |
|                                    |                                          |
|**T2 = max((T1 + (i/x)), arr_time)**    |**T3 = max((T2 + (i/x)), arr_time)**          |
|tick interval i = 1                 |tick interval i = 1                       |
|                                    |                                          |
|**T5 = max((T3 + (i/x)), arr_time)**   |**T4 = max((T3 + (1/x)), arr_time)**          |
|tick interval i = 2 because req5    |tick interval i = 0 because req4          |
|arrived two requests after T2.      |follows immediately after req3 on         |
|                                    |the same queue.                           |
|                                    |[**Note**: If tick_interval == 0, the tag      |
|                                    | is calculated only when it gets to the front|
|                                    |as part of `update_next_tag()` as usual |
|                                    |if DelayedTagCalc is enabled.]            |


For simplicity, assume reservation and limit is set to 3 IOPS, `AtLimit` is set to '`Wait`' and all requests arrived within a second on both queues.

With the fix in place only T0, T1 and T2 will be scheduled as expected during the first phase since each request is spaced` 1/res` apart i.e.,  1/3rd of a second. The same pattern will apply for the rest of the requests in the queues thus ensuring accurate scheduling of requests  across all the queues with the same server.
    
**Tests:**
 A lot of unit tests have been added to exercise the solution with both delayed and immediate tag calculation. Of particular importance are the  tests that completely randomize queue additions and pulls from multiple(5 Nos.)  queues. The tests also provide an insight into how the clients calculate the latest tick interval and how the latest tag is updated by the client via the dynamic functions. See:
     - pull_reservation_randomize_delydtag
     - pull_reservation_randomize_immtag
     - pull_weight_randomize_delydtag
     - pull_weight_randomize_immtag

Signed-off-by: Sridhar Seshasayee <sseshasa@redhat.com>